### PR TITLE
Request encoding

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/config/PayoneConfig.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/config/PayoneConfig.java
@@ -11,6 +11,7 @@ public class PayoneConfig {
 
     public static final String DEFAULT_PAYONE_API_URL = "https://api.pay1.de/post-gateway/";
     public static final String DEFAULT_PAYONE_MODE = "test";
+    public static final String DEFAULT_PAYONE_REQUEST_ENCODING = "UTF-8";
 
     //assure that properties don't change once service started
     private final String subAccountId;
@@ -20,6 +21,7 @@ public class PayoneConfig {
     private final String mode;
     private final String apiUrl;
     private final String apiVersion;
+    private final String encoding;
     private final String solutionName;
     private final String solutionVersion;
     private final String integratorName;
@@ -33,6 +35,7 @@ public class PayoneConfig {
         mode = propertyProvider.getProperty(PropertyProvider.PAYONE_MODE).orElse(DEFAULT_PAYONE_MODE);
         apiUrl = propertyProvider.getProperty(PropertyProvider.PAYONE_API_URL).orElse(DEFAULT_PAYONE_API_URL);
         apiVersion = propertyProvider.getMandatoryNonEmptyProperty(PropertyProvider.PAYONE_API_VERSION);
+        encoding = propertyProvider.getProperty(PropertyProvider.PAYONE_REQUEST_ENCODING).orElse(DEFAULT_PAYONE_REQUEST_ENCODING);
         final String plainKey = propertyProvider.getMandatoryNonEmptyProperty(PropertyProvider.PAYONE_KEY);
         keyAsMd5Hash = Hashing.md5().hashString(plainKey, Charsets.UTF_8).toString();
         solutionName = propertyProvider.getMandatoryNonEmptyProperty(PropertyProvider.PAYONE_SOLUTION_NAME);
@@ -66,6 +69,8 @@ public class PayoneConfig {
     }
 
     public String getApiVersion() { return apiVersion; }
+
+    public String getEncoding() { return encoding; }
 
     public String getSolutionName() { return solutionName; }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 public class PropertyProvider {
 
     public static final String PAYONE_API_VERSION = "PAYONE_API_VERSION";
+    public static final String PAYONE_REQUEST_ENCODING = "PAYONE_REQUEST_ENCODING";
 
     public static final String PAYONE_SOLUTION_NAME = "PAYONE_SOLUTION_NAME";
     public static final String PAYONE_SOLUTION_VERSION = "PAYONE_SOLUTION_VERSION";
@@ -38,6 +39,7 @@ public class PropertyProvider {
     public PropertyProvider() {
         internalProperties = ImmutableMap.<String, String>builder()
             .put(PAYONE_API_VERSION, "3.9")
+            .put(PAYONE_REQUEST_ENCODING, "UTF-8")
             .put(PAYONE_SOLUTION_NAME, "commercetools-platform")
             .put(PAYONE_SOLUTION_VERSION, "1")
             .put(PAYONE_INTEGRATOR_NAME, "commercetools-payone-integration")

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/BaseRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/BaseRequest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public class BaseRequest implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     /**
      * ID of the merchant
@@ -43,6 +43,12 @@ public class BaseRequest implements Serializable {
      */
     @JsonProperty("api_version")
     private String apiVersion;
+
+    /**
+     * {@code ISO 8859-1} or {@code UTF-8}. Default for our implementation is {@code UTF-8},
+     * default for Payone is {@code ISO 8859-1}.
+     */
+    private String encoding;
 
     /**
      * Payone api version
@@ -94,6 +100,7 @@ public class BaseRequest implements Serializable {
         this.mode = config.getMode();
         this.portalid = config.getPortalId();
         this.apiVersion = config.getApiVersion();
+        this.encoding = config.getEncoding();
         this.request = requestType;
         this.solutionName = config.getSolutionName();
         this.solutionVersion = config.getSolutionVersion();
@@ -127,6 +134,10 @@ public class BaseRequest implements Serializable {
 
     public String getApiVersion() {
         return apiVersion;
+    }
+
+    public String getEncoding() {
+        return encoding;
     }
 
     public String getSolutionName() {

--- a/service/src/test/java/com/commercetools/pspadapter/payone/config/PayoneConfigTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/config/PayoneConfigTest.java
@@ -1,10 +1,5 @@
 package com.commercetools.pspadapter.payone.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
-
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 import org.junit.Before;
@@ -14,6 +9,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
 
 /**
  * @author fhaertig
@@ -101,6 +101,19 @@ public class PayoneConfigTest {
     @Test
     public void throwsInCaseOfMissingApiVersion() {
         assertThatThrowsInCaseOfMissingOrEmptyProperty(PropertyProvider.PAYONE_API_VERSION);
+    }
+
+    @Test
+    public void getsEncoding() {
+        when(propertyProvider.getProperty(PropertyProvider.PAYONE_REQUEST_ENCODING)).thenReturn(Optional.of("ISO 8859-1"));
+        assertThat(new PayoneConfig(propertyProvider).getEncoding()).isEqualTo("ISO 8859-1");
+    }
+
+    @Test
+    public void defaultsToTestInCaseOfMissingEncoding() {
+        when(propertyProvider.getProperty(PropertyProvider.PAYONE_REQUEST_ENCODING)).thenReturn(Optional.empty());
+        assertThat(new PayoneConfig(propertyProvider).getEncoding()).isEqualTo(PayoneConfig.DEFAULT_PAYONE_REQUEST_ENCODING);
+        assertThat(PayoneConfig.DEFAULT_PAYONE_REQUEST_ENCODING).isEqualTo("UTF-8");
     }
 
     @Test

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 /**
  * @author mht@dotsource.de
- * 
+ *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class BankTransferInAdvanceRequestFactoryTest {
@@ -65,6 +65,7 @@ public class BankTransferInAdvanceRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(payoneConfig.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(payoneConfig.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(payoneConfig.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(payoneConfig.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(payoneConfig.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(payoneConfig.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(payoneConfig.getIntegratorName());
@@ -72,7 +73,7 @@ public class BankTransferInAdvanceRequestFactoryTest {
 
         //clearing type
         ClearingType clearingType = ClearingType.getClearingTypeByKey("BANK_TRANSFER-ADVANCE");
-        
+
         softly.assertThat(result.getClearingtype()).isEqualTo(clearingType.getPayoneCode());
 
 

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
@@ -83,6 +83,7 @@ public class CreditCardRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(config.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(config.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(config.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(config.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(config.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(config.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(config.getIntegratorName());
@@ -158,6 +159,7 @@ public class CreditCardRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(config.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(config.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(config.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(config.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(config.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(config.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(config.getIntegratorName());
@@ -225,6 +227,7 @@ public class CreditCardRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(config.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(config.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(config.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(config.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(config.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(config.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(config.getIntegratorName());

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactoryTest.java
@@ -71,6 +71,7 @@ public class PaypalRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(config.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(config.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(config.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(config.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(config.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(config.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(config.getIntegratorName());
@@ -147,6 +148,7 @@ public class PaypalRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(config.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(config.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(config.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(config.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(config.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(config.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(config.getIntegratorName());

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
@@ -64,6 +64,7 @@ public class PostfinanceCardRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(payoneConfig.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(payoneConfig.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(payoneConfig.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(payoneConfig.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(payoneConfig.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(payoneConfig.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(payoneConfig.getIntegratorName());

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
@@ -63,6 +63,7 @@ public class SofortRequestFactoryTest {
         softly.assertThat(result.getRequest()).isEqualTo(RequestType.AUTHORIZATION.getType());
         softly.assertThat(result.getAid()).isEqualTo(payoneConfig.getSubAccountId());
         softly.assertThat(result.getMid()).isEqualTo(payoneConfig.getMerchantId());
+        softly.assertThat(result.getEncoding()).isEqualTo(payoneConfig.getEncoding());
         softly.assertThat(result.getPortalid()).isEqualTo(payoneConfig.getPortalId());
         softly.assertThat(result.getKey()).isEqualTo(payoneConfig.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(payoneConfig.getMode());
@@ -155,6 +156,7 @@ public class SofortRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(payoneConfig.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(payoneConfig.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(payoneConfig.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(payoneConfig.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(payoneConfig.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(payoneConfig.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(payoneConfig.getIntegratorName());

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
@@ -67,6 +67,7 @@ public class SofortWithoutIbanRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(payoneConfig.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(payoneConfig.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(payoneConfig.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(payoneConfig.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(payoneConfig.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(payoneConfig.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(payoneConfig.getIntegratorName());
@@ -153,6 +154,7 @@ public class SofortWithoutIbanRequestFactoryTest {
         softly.assertThat(result.getKey()).isEqualTo(payoneConfig.getKeyAsMd5Hash());
         softly.assertThat(result.getMode()).isEqualTo(payoneConfig.getMode());
         softly.assertThat(result.getApiVersion()).isEqualTo(payoneConfig.getApiVersion());
+        softly.assertThat(result.getEncoding()).isEqualTo(payoneConfig.getEncoding());
         softly.assertThat(result.getSolutionName()).isEqualTo(payoneConfig.getSolutionName());
         softly.assertThat(result.getSolutionVersion()).isEqualTo(payoneConfig.getSolutionVersion());
         softly.assertThat(result.getIntegratorName()).isEqualTo(payoneConfig.getIntegratorName());


### PR DESCRIPTION
@butenkor @mht-dotsource @ahalberkamp pls review:

fixed issue #122: added default encoding **`UTF_8`** to all Payone requests