### PR TITLE
Cpi 125 fix route logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ project(":service") {
     dependencies {
         compile 'com.mashape.unirest:unirest-java:1.4.7'
         compile 'com.neovisionaries:nv-i18n:1.17'
-        compile('com.sparkjava:spark-core:2.3') {
+        compile('com.sparkjava:spark-core:2.5.4') {
             exclude group: 'org.slf4j', module: 'slf4j-simple'
         }
         compile 'org.apache.httpcomponents:fluent-hc:4.5.1'

--- a/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
@@ -16,14 +16,11 @@ import org.apache.http.entity.ContentType;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.eclipse.jetty.http.HttpStatus;
-import spark.Redirect;
 import spark.Spark;
 
 import javax.annotation.Nonnull;
 import java.util.ConcurrentModificationException;
 import java.util.concurrent.CompletionException;
-
-import static spark.Spark.redirect;
 
 /**
  * @author fhaertig
@@ -55,8 +52,6 @@ public class IntegrationService {
         createCustomTypes();
 
         Spark.port(port());
-
-        redirect.any("/", "/health", Redirect.Status.MOVED_PERMANENTLY);
 
         // This is a temporary jerry-rig for the load balancer to check connection with the service itself.
         // For now it just returns a JSON response {"status":200}

--- a/service/src/main/resources/log4j.properties
+++ b/service/src/main/resources/log4j.properties
@@ -3,3 +3,6 @@ log4j.logger.deng=INFO
 log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
 log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
 log4j.appender.STDOUT.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
+
+# skip info logs for unmapped routes
+log4j.logger.spark.http.matching.MatcherFilter=warn


### PR DESCRIPTION
@butenkor @ahalberkamp 

i've fixed routes logs with the next changes:
  - update `Spark` version to use the latest API
  - root request **/** now redirected to **/health**
  - raise log level of `MatcherFilter` to _warn_ to avoid logs of unmapped routes.