### PR TITLE
#126 adjust transaction types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,6 @@ deploy:
     all_branches: true
 after_deploy:
   - ./gradlew --continue --info :functionaltests:cleanTest :functionaltests:testSpec publishGhPages || travis_terminate 1
+  - echo "Building service jar file including all dependencies."
+  - ./gradlew stage || travis_terminate 1
   - ./travis-build.sh || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ cache:
   - $HOME/.gradle/wrapper/
 env:
   global:
-  - COMMIT=${TRAVIS_COMMIT::8}
+  - SHORT_COMMIT=${TRAVIS_COMMIT::8}
+  - REPO=sphereio/commercetools-payone-integration
 install: /bin/true
 script:
   - ./gradlew clean ciBuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - COMMIT=${TRAVIS_COMMIT::8}
 install: /bin/true
 script:
-- ./gradlew clean ciBuild
+  - ./gradlew clean ciBuild
 deploy:
   provider: heroku
   api_key:
@@ -25,5 +25,5 @@ deploy:
     repo: commercetools/commercetools-payone-integration
     all_branches: true
 after_deploy:
-- ./gradlew --continue --info :functionaltests:cleanTest :functionaltests:testSpec publishGhPages || travis_terminate 1
-- ./travis-build.sh || travis_terminate 1
+  - ./gradlew --continue --info :functionaltests:cleanTest :functionaltests:testSpec publishGhPages || travis_terminate 1
+  - ./travis-build.sh || travis_terminate 1

--- a/README.md
+++ b/README.md
@@ -230,7 +230,13 @@ Name | Content
 `TEST_DATA_SW_BANK_TRANSFER_IBAN` | the IBAN of a test bank account supporting Sofortueberweisung
 `TEST_DATA_SW_BANK_TRANSFER_BIC` | the BIC of a test bank account supporting Sofortueberweisung
 
-To get a pseudocardpan for a credit card you can use the PAYONE server API. To do this with the client API please refer to the corresponding documentation.
+> **NOTE**: pseudocardpans are used to be expired after some period of time, 
+> so you should update them from time to time in local and Travis build settings.
+> 
+> Could we obtain a new "fresh" pseudocardpan for every build?
+
+To get a pseudocardpan for a credit card you can use the PAYONE server API. 
+To do this with the client API please refer to the corresponding documentation.
 With the server API you simply need to send a POST request of type "3dscheck" for example by using a command line tool:
 
 ```
@@ -245,9 +251,9 @@ Use `md5 -qs $PAYONE_KEY` to hash string value to MD5.
 Don't use `TEST_DATA_VISA_CREDIT_CARD_NO_3DS` or `TEST_DATA_VISA_CREDIT_CARD_3DS` as these values expected to be already pseudocardpan values.
 * Note that the `cardtype` request argument needs to be correspondand: `V` or `M` for _VISA_ and _Master Card_ respectively.
 
-If you have all values above set in [environment variables](#appendix-2-alternative-configuration-via-properties-file), 
-and _md5_ command is available (which is default case on Mac OS X and most of Linux distributions), 
-you may copy-paste and directly execute next line (change only `<VISA_CREDIT_CARD_3DS_NUMBER>`):
+If you have all the values above set in [environment variables](#appendix-2-alternative-configuration-via-properties-file), 
+and _md5_ command is available (which is default case on Mac OS X and most of the Linux distributions), 
+you may copy-paste and directly execute the next line (change only `<VISA_CREDIT_CARD_3DS_NUMBER>`):
 
 ```
 curl --data "request=3dscheck&mid=$PAYONE_MERCHANT_ID&aid=$PAYONE_SUBACC_ID&portalid=$PAYONE_PORTAL_ID&key=$(md5 -qs $PAYONE_KEY)&mode=test&api_version=3.9&amount=2&currency=EUR&clearingtype=cc&exiturl=http://www.example.com&storecarddata=yes&cardexpiredate=2512&cardcvc2=123&cardtype=V&cardpan=<VISA_CREDIT_CARD_3DS_NUMBER>" https://api.pay1.de/post-gateway/

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ def depVersions = [
 allprojects {
     group = 'com.commercetools'
     // NOTE: please also change the version in com.commercetools.pspadapter.payone.config.PropertyProvider when changing the version
-    version = '0.1-SNAPSHOT'
+    version = '1.1.0-SNAPSHOT'
 
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"

--- a/service/src/main/java/com/commercetools/pspadapter/payone/ServiceFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/ServiceFactory.java
@@ -30,7 +30,7 @@ import com.commercetools.pspadapter.payone.transaction.PaymentMethodDispatcher;
 import com.commercetools.pspadapter.payone.transaction.TransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.common.DefaultChargeTransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.common.UnsupportedTransactionExecutor;
-import com.commercetools.pspadapter.payone.transaction.creditcard.AuthorizationTransactionExecutor;
+import com.commercetools.pspadapter.payone.transaction.AuthorizationTransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceChargeTransactionExecutor;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
@@ -218,11 +218,9 @@ public class ServiceFactory {
             final PayonePostService postService,
             final PaymentMethod paymentMethod) {
 
-        switch(transactionType) {
+        switch (transactionType) {
             case AUTHORIZATION:
                 return new AuthorizationTransactionExecutor(typeCache, requestFactory, postService, client);
-            case CANCEL_AUTHORIZATION:
-                break;
             case CHARGE:
                 switch (paymentMethod) {
                     case BANK_TRANSFER_ADVANCE:
@@ -230,6 +228,8 @@ public class ServiceFactory {
                     default:
                         return new DefaultChargeTransactionExecutor(typeCache, requestFactory, postService, client);
                 }
+            case CANCEL_AUTHORIZATION:
+                break;
             case REFUND:
                 break;
             case CHARGEBACK:

--- a/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
@@ -44,7 +44,7 @@ public class PropertyProvider {
             .put(PAYONE_SOLUTION_VERSION, "1")
             .put(PAYONE_INTEGRATOR_NAME, "commercetools-payone-integration")
             // TODO set dynamically
-            .put(PAYONE_INTEGRATOR_VERSION, "0.1-SNAPSHOT")
+            .put(PAYONE_INTEGRATOR_VERSION, "1.1.0-SNAPSHOT")
             .build();
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
@@ -16,7 +16,8 @@ public enum PaymentMethod {
      * @see MethodKeys#DIRECT_DEBIT_SEPA
      */
     DIRECT_DEBIT_SEPA(MethodKeys.DIRECT_DEBIT_SEPA,
-                    TransactionType.AUTHORIZATION
+                    TransactionType.AUTHORIZATION,
+                    TransactionType.CHARGE
     ),
 
     /**
@@ -38,20 +39,23 @@ public enum PaymentMethod {
      * @see MethodKeys#BANK_TRANSFER_SOFORTUEBERWEISUNG
      */
     BANK_TRANSFER_SOFORTUEBERWEISUNG(MethodKeys.BANK_TRANSFER_SOFORTUEBERWEISUNG,
-                    TransactionType.CHARGE
+            TransactionType.AUTHORIZATION,
+            TransactionType.CHARGE
     ),
 
     /**
      * @see MethodKeys#BANK_TRANSFER_ADVANCE
      */
     BANK_TRANSFER_ADVANCE(MethodKeys.BANK_TRANSFER_ADVANCE,
-                    TransactionType.CHARGE
+                    TransactionType.AUTHORIZATION,
+                    TransactionType.CHARGE // not supported by the documentation, but works, hence left for the backward compatibility
     ),
 
     /**
      * @see MethodKeys#BANK_TRANSFER_SOFORTUEBERWEISUNG
      */
     BANK_TRANSFER_POSTFINANCE_EFINANCE(MethodKeys.BANK_TRANSFER_POSTFINANCE_EFINANCE,
+            TransactionType.AUTHORIZATION,
             TransactionType.CHARGE
     ),
 
@@ -59,6 +63,7 @@ public enum PaymentMethod {
      * @see MethodKeys#BANK_TRANSFER_SOFORTUEBERWEISUNG
      */
     BANK_TRANSFER_POSTFINANCE_CARD(MethodKeys.BANK_TRANSFER_POSTFINANCE_CARD,
+            TransactionType.AUTHORIZATION,
             TransactionType.CHARGE
     );
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferAuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferAuthorizationRequest.java
@@ -1,68 +1,12 @@
 package com.commercetools.pspadapter.payone.domain.payone.model.banktransfer;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
-import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
 
-/**
- * @author fhaertig
- * @since 22.01.16
- */
-public class BankTransferAuthorizationRequest extends AuthorizationRequest {
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType.AUTHORIZATION;
 
-    private String onlinebanktransfertype;
-
-    private String bankcountry;
-
-    @ClearSecuredValuesSerializer.Apply
-    private String iban;
-
-    @ClearSecuredValuesSerializer.Apply
-    private String bic;
+public class BankTransferAuthorizationRequest extends BaseBankTransferAuthorizationRequest {
 
     public BankTransferAuthorizationRequest(final PayoneConfig config, final String onlinebanktransfertype) {
-        super(config, RequestType.AUTHORIZATION.getType(), ClearingType.PAYONE_PNT.getPayoneCode());
-
-        this.onlinebanktransfertype = onlinebanktransfertype;
-    }
-
-    //**************************************************************
-    //* GETTER AND SETTER METHODS
-    //**************************************************************
-
-
-    public String getOnlinebanktransfertype() {
-        return onlinebanktransfertype;
-    }
-
-    public void setOnlinebanktransfertype(final String onlinebanktransfertype) {
-        this.onlinebanktransfertype = onlinebanktransfertype;
-    }
-
-    public String getBankcountry() {
-        return bankcountry;
-    }
-
-    public void setBankcountry(String bankcountry) {
-        this.bankcountry = bankcountry;
-    }
-
-
-    public String getIban() {
-        return iban;
-    }
-
-    public void setIban(final String iban) {
-        this.iban = iban;
-    }
-
-    public String getBic() {
-        return bic;
-    }
-
-    public void setBic(final String bic) {
-        this.bic = bic;
+        super(config, AUTHORIZATION, onlinebanktransfertype);
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferPreathorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferPreathorizationRequest.java
@@ -1,0 +1,12 @@
+package com.commercetools.pspadapter.payone.domain.payone.model.banktransfer;
+
+import com.commercetools.pspadapter.payone.config.PayoneConfig;
+
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType.PREAUTHORIZATION;
+
+public class BankTransferPreathorizationRequest extends BaseBankTransferAuthorizationRequest {
+
+    public BankTransferPreathorizationRequest(final PayoneConfig config, final String onlinebanktransfertype) {
+        super(config, PREAUTHORIZATION, onlinebanktransfertype);
+    }
+}

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BaseBankTransferAuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BaseBankTransferAuthorizationRequest.java
@@ -1,0 +1,73 @@
+package com.commercetools.pspadapter.payone.domain.payone.model.banktransfer;
+
+import com.commercetools.pspadapter.payone.config.PayoneConfig;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
+import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base class for all bank transfer <b>authorisation/preauthorization</b> requests,
+ * including postfinance, sofort and so on.
+ */
+public class BaseBankTransferAuthorizationRequest extends AuthorizationRequest {
+
+    private String onlinebanktransfertype;
+
+    private String bankcountry;
+
+    @ClearSecuredValuesSerializer.Apply
+    private String iban;
+
+    @ClearSecuredValuesSerializer.Apply
+    private String bic;
+
+    BaseBankTransferAuthorizationRequest(final PayoneConfig config, final RequestType request,
+                                                final String onlinebanktransfertype) {
+        super(config, request.getType(), ClearingType.PAYONE_PNT.getPayoneCode());
+
+        this.onlinebanktransfertype = onlinebanktransfertype;
+    }
+
+    //**************************************************************
+    //* GETTER AND SETTER METHODS
+    //**************************************************************
+
+
+    public String getOnlinebanktransfertype() {
+        return onlinebanktransfertype;
+    }
+
+    public void setOnlinebanktransfertype(final String onlinebanktransfertype) {
+        this.onlinebanktransfertype = onlinebanktransfertype;
+    }
+
+    @Nullable
+    public String getBankcountry() {
+        return bankcountry;
+    }
+
+    public void setBankcountry(String bankcountry) {
+        this.bankcountry = bankcountry;
+    }
+
+
+    @Nullable
+    public String getIban() {
+        return iban;
+    }
+
+    public void setIban(final String iban) {
+        this.iban = iban;
+    }
+
+    public String getBic() {
+        return bic;
+    }
+
+    public void setBic(final String bic) {
+        this.bic = bic;
+    }
+}

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactory.java
@@ -2,17 +2,12 @@ package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.wallet.WalletAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.wallet.WalletPreauthorizationRequest;
-import com.google.common.base.Preconditions;
-import io.sphere.sdk.carts.CartLike;
-import io.sphere.sdk.payments.Payment;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
+import javax.annotation.Nonnull;
 
 /**
  * @author fhaertig
@@ -27,56 +22,12 @@ public class PaypalRequestFactory extends PayoneRequestFactory {
     }
 
     @Override
-    public WalletPreauthorizationRequest createPreauthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
-
-        final Payment ctPayment = paymentWithCartLike.getPayment();
-        final CartLike ctCartLike = paymentWithCartLike.getCartLike();
-
-        Preconditions.checkArgument(ctPayment.getCustom() != null, "Missing custom fields on payment!");
-
-        final String clearingSubType = ClearingType.getClearingTypeByKey(ctPayment.getPaymentMethodInfo().getMethod()).getSubType();
-        WalletPreauthorizationRequest request = new WalletPreauthorizationRequest(getPayoneConfig(), clearingSubType);
-
-        request.setReference(paymentWithCartLike.getReference());
-
-        Optional.ofNullable(ctPayment.getAmountPlanned())
-                .ifPresent(amount -> {
-                    request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(MonetaryUtil
-                            .minorUnits()
-                            .queryFrom(amount)
-                            .intValue());
-                });
-
-        mapFormPaymentWithCartLike(request, paymentWithCartLike, LOG);
-
-        return request;
+    public WalletPreauthorizationRequest createPreauthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
+        return createBasicAuthorizationRequest(paymentWithCartLike, WalletPreauthorizationRequest::new, LOG);
     }
 
     @Override
-    public WalletAuthorizationRequest createAuthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
-
-        final Payment ctPayment = paymentWithCartLike.getPayment();
-        final CartLike ctCartLike = paymentWithCartLike.getCartLike();
-
-        Preconditions.checkArgument(ctPayment.getCustom() != null, "Missing custom fields on payment!");
-
-        final String clearingSubType = ClearingType.getClearingTypeByKey(ctPayment.getPaymentMethodInfo().getMethod()).getSubType();
-        WalletAuthorizationRequest request = new WalletAuthorizationRequest(getPayoneConfig(), clearingSubType);
-
-        request.setReference(paymentWithCartLike.getReference());
-
-        Optional.ofNullable(ctPayment.getAmountPlanned())
-                .ifPresent(amount -> {
-                    request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(MonetaryUtil
-                            .minorUnits()
-                            .queryFrom(amount)
-                            .intValue());
-                });
-
-        mapFormPaymentWithCartLike(request, paymentWithCartLike, LOG);
-
-        return request;
+    public WalletAuthorizationRequest createAuthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
+        return createBasicAuthorizationRequest(paymentWithCartLike, WalletAuthorizationRequest::new, LOG);
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PostFinanceBanktransferRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PostFinanceBanktransferRequestFactory.java
@@ -2,7 +2,9 @@ package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BaseBankTransferAuthorizationRequest;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author mht@dotsource.de
@@ -14,8 +16,8 @@ public class PostFinanceBanktransferRequestFactory extends BankTransferWithoutIb
     }
 
     @Override
-    public BankTransferAuthorizationRequest createAuthorizationRequest(PaymentWithCartLike paymentWithCartLike) {
-        final BankTransferAuthorizationRequest request = super.createAuthorizationRequest(paymentWithCartLike);
+    public BaseBankTransferAuthorizationRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+        final BaseBankTransferAuthorizationRequest request = super.createAuthorizationRequest(paymentWithCartLike);
         //Despite declared as optional in PayOne Server API documentation. this is required!
         request.setBankcountry("CH");
         return request;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/AuthorizationTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/AuthorizationTransactionExecutor.java
@@ -1,4 +1,4 @@
-package com.commercetools.pspadapter.payone.transaction.creditcard;
+package com.commercetools.pspadapter.payone.transaction;
 
 import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
@@ -7,7 +7,6 @@ import com.commercetools.pspadapter.payone.domain.payone.exceptions.PayoneExcept
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.commercetools.pspadapter.payone.transaction.TransactionBaseExecutor;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -21,6 +20,7 @@ import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
 import io.sphere.sdk.payments.commands.updateactions.*;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.ZonedDateTime;
 import java.util.ConcurrentModificationException;
@@ -51,7 +51,7 @@ public class AuthorizationTransactionExecutor extends TransactionBaseExecutor {
 
             return getCustomFieldsOfType(paymentWithCartLike, CustomTypeBuilder.PAYONE_INTERACTION_NOTIFICATION)
                     //sequenceNumber field is mandatory -> can't be null
-                    .anyMatch(fields -> fields.getFieldAsString(CustomFieldKeys.SEQUENCE_NUMBER_FIELD).equals(transaction.getInteractionId()));
+                    .anyMatch(fields -> StringUtils.equals(fields.getFieldAsString(CustomFieldKeys.SEQUENCE_NUMBER_FIELD), transaction.getInteractionId()));
         } else {
             return true;
         }

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
@@ -3,7 +3,7 @@ package com.commercetools.pspadapter.payone.mapping;
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BaseBankTransferAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import io.sphere.sdk.customers.Customer;
@@ -53,7 +53,7 @@ public class PostfinanceCardRequestFactoryTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BaseBankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
@@ -4,7 +4,7 @@ import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
 import com.commercetools.pspadapter.payone.config.ServiceConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BaseBankTransferAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import io.sphere.sdk.customers.Customer;
@@ -53,7 +53,7 @@ public class PostfinanceEfinanceRequestFactoryTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BaseBankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
@@ -4,7 +4,7 @@ import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
 import com.commercetools.pspadapter.payone.config.ServiceConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BaseBankTransferAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import io.sphere.sdk.customers.Customer;
@@ -56,7 +56,7 @@ public class SofortRequestFactoryTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BaseBankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values
@@ -145,7 +145,7 @@ public class SofortRequestFactoryTest {
         Order order = payments.dummyOrderMapToPayoneRequest();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BaseBankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
@@ -4,7 +4,7 @@ import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
 import com.commercetools.pspadapter.payone.config.ServiceConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BaseBankTransferAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import io.sphere.sdk.customers.Customer;
@@ -56,7 +56,7 @@ public class SofortWithoutIbanRequestFactoryTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BaseBankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values
@@ -143,7 +143,7 @@ public class SofortWithoutIbanRequestFactoryTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BaseBankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/AuthorizationTransactionExecutorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/AuthorizationTransactionExecutorTest.java
@@ -1,4 +1,4 @@
-package com.commercetools.pspadapter.payone.transaction.creditcard;
+package com.commercetools.pspadapter.payone.transaction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -3,9 +3,14 @@
 set -e
 
 export REPO="sphereio/commercetools-payone-integration"
-export DOCKER_TAG=`if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "latest"; else echo ${TRAVIS_BRANCH} | sed -e 's/#//g' -e 's/\\/-/g' ; fi`
-# where sed -e 's/#//g' -e 's/\\/-/g' is: remove [ # ] and replace [ \ -> - ] in the branch name
+export DOCKER_TAG=`if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "latest"; else echo ${TRAVIS_BRANCH} | sed -e 's/#//g' -e 's/\\\\/-/g' ; fi`
+# where sed -e 's/#//g' -e 's/\\\\/-/g' is: remove [ # ] and replace [ \ -> - ] in the branch name
 
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+echo "DOCKER_TAG                = $DOCKER_TAG"
+echo "COMMIT TAG                = $COMMIT"
+echo "TRAVIS_BUILD_NUMBER TAG   = $TRAVIS_BUILD_NUMBER"
+echo "TRAVIS_TAG                = $TRAVIS_TAG"
 
 echo "Building service jar file including all dependencies."
 ./gradlew stage

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export PRODUCTION_TAG="production"
+
 export DOCKER_TAG=`if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]] || [[ "$TRAVIS_TAG" ]] ; \
   then echo "latest" ; \
   else echo "wip-${TRAVIS_BRANCH}" | sed -e 's/#//g' -e 's/\\\\/-/g' ; fi`

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -3,7 +3,9 @@
 set -e
 
 export REPO="sphereio/commercetools-payone-integration"
-export DOCKER_TAG=`if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "latest"; else echo ${TRAVIS_BRANCH//\//-} ; fi`
+export DOCKER_TAG=`if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "latest"; else echo ${TRAVIS_BRANCH} | sed -e 's/#//g' -e 's/\\/-/g' ; fi`
+# where sed -e 's/#//g' -e 's/\\/-/g' is: remove [ # ] and replace [ \ -> - ] in the branch name
+
 
 echo "Building service jar file including all dependencies."
 ./gradlew stage

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -2,34 +2,38 @@
 
 set -e
 
-export REPO="sphereio/commercetools-payone-integration"
-export DOCKER_TAG=`if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "latest"; else echo ${TRAVIS_BRANCH} | sed -e 's/#//g' -e 's/\\\\/-/g' ; fi`
-# where sed -e 's/#//g' -e 's/\\\\/-/g' is: remove [ # ] and replace [ \ -> - ] in the branch name
+export DOCKER_TAG=`if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]] || [[ "$TRAVIS_TAG" ]] ; \
+  then echo "latest" ; \
+  else echo "wip-${TRAVIS_BRANCH}" | sed -e 's/#//g' -e 's/\\\\/-/g' ; fi`
+# where sed -e 's/#//g' -e 's/\\\\/-/g' means: remove "#" and replace "\" -> "-" in the branch name
 
-echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-echo "DOCKER_TAG                = $DOCKER_TAG"
-echo "COMMIT TAG                = $COMMIT"
-echo "TRAVIS_BUILD_NUMBER TAG   = $TRAVIS_BUILD_NUMBER"
-echo "TRAVIS_TAG                = $TRAVIS_TAG"
+# used for debugging the build, may be suppressed in production
+echo REPO=$REPO
+echo TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
+echo TRAVIS_TAG=$TRAVIS_TAG
+echo SHORT_COMMIT=$SHORT_COMMIT
+echo DOCKER_TAG=$DOCKER_TAG
+echo PRODUCTION_TAG=$PRODUCTION_TAG
 
-echo "Building service jar file including all dependencies."
-./gradlew stage
-
-echo "Building Docker image using tag '${REPO}:${COMMIT}'."
-docker build -t "${REPO}:${COMMIT}" .
+echo "Building Docker image using tag '${REPO}:${SHORT_COMMIT}'."
+docker build -t "${REPO}:${SHORT_COMMIT}" .
 
 docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
 
-echo "Adding additional tag '${REPO}:${DOCKER_TAG}' to already built Docker image '${REPO}:${COMMIT}'."
-docker tag $REPO:$COMMIT $REPO:$DOCKER_TAG
-echo "Adding additional tag '${REPO}:travis-${TRAVIS_BUILD_NUMBER}' to already built Docker image '${REPO}:${COMMIT}'."
-docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
+echo "Adding additional tag '${REPO}:${DOCKER_TAG}' to already built Docker image '${REPO}:${SHORT_COMMIT}'."
+docker tag $REPO:$SHORT_COMMIT $REPO:$DOCKER_TAG
+
+echo "Adding additional tag '${REPO}:travis-${TRAVIS_BUILD_NUMBER}' to already built Docker image '${REPO}:${SHORT_COMMIT}'."
+docker tag $REPO:$SHORT_COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
+
 if [ "$TRAVIS_TAG" ]; then
-  echo "Adding additional tag '${REPO}:${TRAVIS_TAG}' to already built Docker image '${REPO}:${COMMIT}'."
-  docker tag $REPO:$COMMIT $REPO:${TRAVIS_TAG};
-  echo "Adding additional tag '${REPO}:production' to already built Docker image '${REPO}:${COMMIT}'."
-  docker tag $REPO:$COMMIT $REPO:production;
+  echo "Adding additional tag '${REPO}:${TRAVIS_TAG}' to already built Docker image '${REPO}:${SHORT_COMMIT}'."
+  docker tag $REPO:$SHORT_COMMIT $REPO:${TRAVIS_TAG}
+
+  echo "Adding additional tag '${REPO}:${PRODUCTION_TAG}' to already built Docker image '${REPO}:${SHORT_COMMIT}'."
+  docker tag $REPO:$SHORT_COMMIT $REPO:${PRODUCTION_TAG}
 fi
+
 echo "Pushing Docker images to repository '${REPO}' (all local tags are pushed)."
 docker push $REPO
 docker logout


### PR DESCRIPTION
@butenkor @ahalberkamp 

This is an old branch with already released version `1.1.0-SNAPSHOT` which we forgot to move to master after "emergency" fixes for Carhartt project.

The main fixes: 
  - now authorization and charge transactions are supported by all payment methods (see [PaymentMethod](https://github.com/commercetools/commercetools-payone-integration/blob/4cda530d57fd24b2a1a99d17d875352b07c8300d/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java))

  - build script is adjusted to conventional "latest" and "production" tags generation.