### PR TITLE
#176: fix sofortüberweisung integration tests

### DIFF
--- a/functionaltests/src/test/java/specs/paymentmethods/sofortueberweisung/ChargeImmediatelyFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/sofortueberweisung/ChargeImmediatelyFixture.java
@@ -177,7 +177,7 @@ public class ChargeImmediatelyFixture extends BaseNotifiablePaymentFixture {
      * Simulate customer's payment approval: log in in browser, set field values, press submit buttons.
      *
      * @param paymentName payment name to approve
-     * @return 1 if items is approved, 0 - if approval was not possible.
+     * @return 1 if payment is approved, 0 - if approval was not possible.
      */
     private int approvePaymentAsCustomer(String paymentName) {
         final Payment payment = fetchPaymentByLegibleName(paymentName);

--- a/functionaltests/src/test/java/util/WebDriver3ds.java
+++ b/functionaltests/src/test/java/util/WebDriver3ds.java
@@ -50,7 +50,7 @@ public class WebDriver3ds extends HtmlUnitDriver {
      * Submits the given {@code password} at the given {@code url}'s "password" element, waits for a redirect and
      * returns the URL it was redirected to.
      *
-     * @param url the URL to navigate to
+     * @param url      the URL to navigate to
      * @param password the password
      * @return the URL the browser was redirected to after submitting the {@code password}
      */

--- a/functionaltests/src/test/java/util/WebDriverSofortueberweisung.java
+++ b/functionaltests/src/test/java/util/WebDriverSofortueberweisung.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
-import static util.constant.WebDriverCommon.XPATH_SUBMIT;
+import static util.constant.WebDriverCommon.CLASS_NAME_PRIMARY;
 import static util.constant.WebDriverSofortueberweisungConstants.*;
 
 /**
@@ -26,6 +26,8 @@ import static util.constant.WebDriverSofortueberweisungConstants.*;
 public class WebDriverSofortueberweisung extends HtmlUnitDriver {
 
     private static final int DEFAULT_TIMEOUT = 5;
+
+    private final Wait<WebDriver> wait;
 
     public WebDriverSofortueberweisung() {
         super(BrowserVersion.FIREFOX_45, true);
@@ -46,28 +48,35 @@ public class WebDriverSofortueberweisung extends HtmlUnitDriver {
             //swallow these messages
         });
         webClient.setCssErrorHandler(new SilentCssErrorHandler());
+
+        this.wait = new WebDriverWait(this, 20);
     }
 
     private void doLogin(String userid, String pin) {
         final WebElement useridInput = findElement(By.id(SU_LOGIN_NAME_ID));
-        final WebElement pinInput = findElement(By.id(SU_USER_PIN_ID));
+
+        wait.until(ExpectedConditions.elementToBeClickable(useridInput));
         useridInput.clear();
         useridInput.sendKeys(userid);
+
+        final WebElement pinInput = findElement(By.id(SU_USER_PIN_ID));
+        wait.until(ExpectedConditions.elementToBeClickable(pinInput));
         pinInput.sendKeys(pin);
 
         final WebElement submitButton = findSubmitButton();
+        wait.until(ExpectedConditions.elementToBeClickable(submitButton));
         submitButton.click();
     }
 
     /**
-     * Search for the single submit button on the page by xpath pattern from {@link util.constant.WebDriverCommon#XPATH_SUBMIT}
+     * Search for the single submit button on the page by className pattern from
+     * {@link util.constant.WebDriverCommon#CLASS_NAME_PRIMARY}
+     *
      * @return found button.
-     * @throws {@link RuntimeException} if submit button can't be found or multiply buttons exist on the page
+     * @throws RuntimeException if submit button can't be found or multiply buttons exist on the page
      */
     private WebElement findSubmitButton() {
-        // note: earlier we used By.cssSelector("button[type=submit]"), but this does not separate properly other buttons,
-        // thus we use now xpath, which looks more proper solutions in this case
-        List<WebElement> elements = findElements(By.xpath(XPATH_SUBMIT));
+        List<WebElement> elements = findElements(By.className(CLASS_NAME_PRIMARY));
         if (elements == null || elements.size() != 1) {
             throw new RuntimeException("Submit button not found on the page");
         }
@@ -78,9 +87,12 @@ public class WebDriverSofortueberweisung extends HtmlUnitDriver {
 
     private void selectAccount() {
         final WebElement senderAccountInput = findElement(By.id(SU_TEST_ACCOUNT_RADIO_BUTTON));
-        final WebElement submitButton = findSubmitButton();
 
+        wait.until(ExpectedConditions.elementToBeClickable(senderAccountInput));
         senderAccountInput.click();
+
+        final WebElement submitButton = findSubmitButton();
+        wait.until(ExpectedConditions.elementToBeClickable(submitButton));
         submitButton.click();
     }
 
@@ -88,7 +100,10 @@ public class WebDriverSofortueberweisung extends HtmlUnitDriver {
         final WebElement tanInput = findElement(By.id(SU_BACKEND_FORM_TAN));
         final WebElement submitButton = findSubmitButton();
 
+        wait.until(ExpectedConditions.elementToBeClickable(tanInput));
         tanInput.sendKeys(tan);
+
+        wait.until(ExpectedConditions.elementToBeClickable(submitButton));
         submitButton.click();
     }
 
@@ -96,23 +111,18 @@ public class WebDriverSofortueberweisung extends HtmlUnitDriver {
      * Submits the given {@code password} at the given {@code url}'s "password" element, waits for a redirect and
      * returns the URL it was redirected to.
      *
-     * @param url the URL to navigate to
+     * @param url    the URL to navigate to
      * @param userid the account id to use
      * @return the URL the browser was redirected to after submitting the {@code password}
      */
     public String executeSofortueberweisungRedirect(final String url, final String userid, final String pin, final String tan) {
-        final Wait<WebDriver> wait = new WebDriverWait(this, 20);
-
         navigate().to(url);
-
         doLogin(userid, pin);
 
         wait.until(ExpectedConditions.urlContains(SU_URL_SELECT_ACCOUNT_PATTERN));
-
         selectAccount();
 
         wait.until(ExpectedConditions.urlContains(SU_URL_PROVIDE_TAN_PATTERN));
-
         provideTan(tan);
 
         wait.until(not(ExpectedConditions.urlContains(SU_URL_PAY_1_PATTERN)));

--- a/functionaltests/src/test/java/util/constant/WebDriverCommon.java
+++ b/functionaltests/src/test/java/util/constant/WebDriverCommon.java
@@ -5,7 +5,9 @@ package util.constant;
  */
 public final class WebDriverCommon {
 
-    public static final String XPATH_SUBMIT = "//button[@type='submit']";
+    //public static final String XPATH_SUBMIT = "//button[@type='submit']";
+    public static final String CLASS_NAME_PRIMARY = "primary";
+
     public static final String CSS_SELECTOR_PASSWORD = "input[type=password]";
     public static final String CSS_SELECTOR_SEND = "input[name=send]";
 

--- a/functionaltests/src/test/java/util/constant/WebDriverSofortueberweisungConstants.java
+++ b/functionaltests/src/test/java/util/constant/WebDriverSofortueberweisungConstants.java
@@ -22,8 +22,12 @@ public final class WebDriverSofortueberweisungConstants {
 
     /**
      * Name of radio button input with account to select for tests after log-in process.
+     * <pre>
+     * Girokonto (Max Mustermann)
+     * DE06000000000023456789
+     * </pre>
      */
-    public static final String SU_TEST_ACCOUNT_RADIO_BUTTON = "MultipaysSessionSenderAccountNumberTechnical23456789";
+    public static final String SU_TEST_ACCOUNT_RADIO_BUTTON = "account-1";
 
     public static final String SU_URL_SELECT_ACCOUNT_PATTERN = "select_account";
     public static final String SU_URL_PROVIDE_TAN_PATTERN = "provide_tan";


### PR DESCRIPTION
This PR solves 2 problems in Sofortüberweisung tests:
  - fixes the references according to new web page controls/input names (see [this](https://github.com/commercetools/commercetools-payone-integration/pull/180/files#diff-fb901a72f37294c99b6a07524e574e4cR8) and [this](https://github.com/commercetools/commercetools-payone-integration/pull/180/files#diff-9f9c9c48c18aee576acface9676dc372R30))
  - wait for inputs to be enabled before clicking them, because they are enabled asynchronously when you change other inputs values (for example, _login_ button is enabled only when both name and tan are input). See [`ExpectedConditions.elementToBeClickable` usage](https://github.com/commercetools/commercetools-payone-integration/pull/180/files#diff-4887a49c8d02ab752b32e97b6c562762R57)
  - run all 3 payment approval processes in parallel, so we are not blocked by sequential order of 3 slow processes, see [ChargeImmediatelyFixture](https://github.com/commercetools/commercetools-payone-integration/pull/180/files#diff-7002363f5ae20d66bde6951afee8b452R169)