### PR TITLE
175 update jvm sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ def depVersions = [
         hamcrest: '1.3',
         jUnit: '4.12',
         assertJ: '3.8.0',
-        moneta: '1.1',
         slf4jLogbackClassic: '1.2.2',
         slf4jLog4j: '1.7.25'
 ]
@@ -49,7 +48,6 @@ subprojects {
             exclude group: 'org.assertj'
         }
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
-        implementation "org.javamoney:moneta:$depVersions.moneta"
         implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
         implementation "org.assertj:assertj-core:${depVersions.assertJ}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,16 @@ plugins {
 
 def depVersions = [
         commercetoolsSdkJvm: '1.24.0',
+        fluentHc: '4.5.1',
         guava: '19.0',
         hamcrest: '1.3',
         jUnit: '4.12',
         assertJ: '3.8.0',
         slf4jLogbackClassic: '1.2.2',
-        slf4jLog4j: '1.7.25'
+        slf4jLog4j: '1.7.25',
+        unirest: '1.4.7',
+        hamcrestDate: '2.0.1',
+        mockito: '1.10.19'
 ]
 
 allprojects {
@@ -50,6 +54,8 @@ subprojects {
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
         implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
         implementation "org.assertj:assertj-core:${depVersions.assertJ}"
+        implementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
+        implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"
 
         testImplementation "junit:junit:$depVersions.jUnit"
         testImplementation "org.hamcrest:hamcrest-core:$depVersions.hamcrest"
@@ -70,17 +76,15 @@ project(":service") {
     mainClassName = 'com.commercetools.Main'
 
     dependencies {
-        implementation 'com.mashape.unirest:unirest-java:1.4.7'
         implementation 'com.neovisionaries:nv-i18n:1.17'
         implementation('com.sparkjava:spark-core:2.5.4') {
             exclude group: 'org.slf4j', module: 'slf4j-simple'
         }
-        implementation 'org.apache.httpcomponents:fluent-hc:4.5.1'
         implementation 'org.quartz-scheduler:quartz:2.2.2'
 
         testImplementation "org.assertj:assertj-core:${depVersions.assertJ}"
-        testImplementation 'org.exparity:hamcrest-date:2.0.1'
-        testImplementation 'org.mockito:mockito-core:1.10.19'
+        testImplementation "org.exparity:hamcrest-date:${depVersions.hamcrestDate}"
+        testImplementation "org.mockito:mockito-core:${depVersions.mockito}"
     }
 
     shadowJar {
@@ -238,16 +242,16 @@ static void assertExecutableSpecRequirementsForTests(Project project, Test test)
 
 project(":functionaltests") {
     dependencies {
-        compile project(":service")
+        testImplementation project(":service")
 
-        testCompile 'org.concordion:concordion:1.5.1'
-        testCompile 'org.concordion:concordion-input-style-extension:0.1'
-        testCompile 'org.concordion:concordion-run-totals-extension:1.0.0'
-        testCompile 'org.concordion:concordion-parallel-run-extension:1.0.1'
-        testCompile 'org.seleniumhq.selenium:selenium-java:2.53.1'
+        testImplementation 'org.concordion:concordion:1.5.1'
+        testImplementation 'org.concordion:concordion-input-style-extension:0.1'
+        testImplementation 'org.concordion:concordion-run-totals-extension:1.0.0'
+        testImplementation 'org.concordion:concordion-parallel-run-extension:1.0.1'
+        testImplementation 'org.seleniumhq.selenium:selenium-java:2.53.1'
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings
-        testCompile "org.slf4j:log4j-over-slf4j:$depVersions.slf4jLog4j"
+        testImplementation "org.slf4j:log4j-over-slf4j:$depVersions.slf4jLog4j"
     }
 
     compileJava.dependsOn ':service:jar'

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ def depVersions = [
         commercetoolsSdkJvm: '1.25.0',
         fluentHc: '4.5.3',
         guava: '23.0',
+        quartz: '2.3.0',
         hamcrest: '1.3',
         jUnit: '4.12',
         assertJ: '3.8.0',
@@ -72,7 +73,7 @@ project(":service") {
         implementation('com.sparkjava:spark-core:2.5.4') {
             exclude group: 'org.slf4j', module: 'slf4j-simple'
         }
-        implementation 'org.quartz-scheduler:quartz:2.2.2'
+        implementation "org.quartz-scheduler:quartz:${depVersions.quartz}"
 
         testImplementation "junit:junit:$depVersions.jUnit"
         testImplementation "org.hamcrest:hamcrest-library:$depVersions.hamcrest"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 def depVersions = [
-        commercetoolsSdkJvm: '1.13.0',
+        commercetoolsSdkJvm: '1.24.0',
         guava: '19.0',
         hamcrest: '1.3',
         jUnit: '4.12',

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ subprojects {
         }
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
         implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
-        implementation "org.assertj:assertj-core:${depVersions.assertJ}"
         implementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
         implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,10 @@ def depVersions = [
         hamcrest: '1.3',
         jUnit: '4.12',
         assertJ: '3.8.0',
-        slf4jLogbackClassic: '1.2.2',
+        slf4jLogbackClassic: '1.2.3',
         slf4jLog4j: '1.7.25',
         unirest: '1.4.9',
-        hamcrestDate: '2.0.1',
+        hamcrestDate: '2.0.4',
         mockito: '1.10.19'
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,6 @@ subprojects {
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
         implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
         implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"
-
-        testImplementation "junit:junit:$depVersions.jUnit"
-        testImplementation "org.hamcrest:hamcrest-library:$depVersions.hamcrest"
     }
 
 }
@@ -78,6 +75,8 @@ project(":service") {
         }
         implementation 'org.quartz-scheduler:quartz:2.2.2'
 
+        testImplementation "junit:junit:$depVersions.jUnit"
+        testImplementation "org.hamcrest:hamcrest-library:$depVersions.hamcrest"
         testImplementation "org.assertj:assertj-core:${depVersions.assertJ}"
         testImplementation "org.mockito:mockito-core:${depVersions.mockito}"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -47,12 +47,12 @@ subprojects {
     }
 
     dependencies {
-        implementation "com.google.guava:guava:$depVersions.guava"
-        implementation ("com.commercetools.sdk.jvm.core:commercetools-java-client:$depVersions.commercetoolsSdkJvm") {
+        implementation "com.google.guava:guava:${depVersions.guava}"
+        implementation ("com.commercetools.sdk.jvm.core:commercetools-java-client:${depVersions.commercetoolsSdkJvm}") {
             exclude group: 'org.assertj'
         }
-        implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
-        implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
+        implementation "com.commercetools.sdk.jvm.core:commercetools-models:${depVersions.commercetoolsSdkJvm}"
+        implementation "ch.qos.logback:logback-classic:${depVersions.slf4jLogbackClassic}"
         implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"
     }
 
@@ -75,8 +75,8 @@ project(":service") {
         }
         implementation "org.quartz-scheduler:quartz:${depVersions.quartz}"
 
-        testImplementation "junit:junit:$depVersions.jUnit"
-        testImplementation "org.hamcrest:hamcrest-library:$depVersions.hamcrest"
+        testImplementation "junit:junit:${depVersions.jUnit}"
+        testImplementation "org.hamcrest:hamcrest-library:${depVersions.hamcrest}"
         testImplementation "org.assertj:assertj-core:${depVersions.assertJ}"
         testImplementation "org.mockito:mockito-core:${depVersions.mockito}"
     }
@@ -248,7 +248,7 @@ project(":functionaltests") {
         testImplementation 'org.seleniumhq.selenium:selenium-java:2.53.1'
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings
-        testImplementation "org.slf4j:log4j-over-slf4j:$depVersions.slf4jLog4j"
+        testImplementation "org.slf4j:log4j-over-slf4j:${depVersions.slf4jLog4j}"
 
         testImplementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 def depVersions = [
-        commercetoolsSdkJvm: '1.24.0',
+        commercetoolsSdkJvm: '1.25.0',
         fluentHc: '4.5.1',
         guava: '19.0',
         hamcrest: '1.3',

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def depVersions = [
         assertJ: '3.8.0',
         slf4jLogbackClassic: '1.2.2',
         slf4jLog4j: '1.7.25',
-        unirest: '1.4.7',
+        unirest: '1.4.9',
         hamcrestDate: '2.0.1',
         mockito: '1.10.19'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 def depVersions = [
         commercetoolsSdkJvm: '1.25.0',
+        sparkCore: '2.6.0',
         fluentHc: '4.5.3',
         guava: '23.0',
         quartz: '2.3.0',
@@ -70,7 +71,7 @@ project(":service") {
     mainClassName = 'com.commercetools.Main'
 
     dependencies {
-        implementation('com.sparkjava:spark-core:2.5.4') {
+        implementation("com.sparkjava:spark-core:${depVersions.sparkCore}") {
             exclude group: 'org.slf4j', module: 'slf4j-simple'
         }
         implementation "org.quartz-scheduler:quartz:${depVersions.quartz}"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 def depVersions = [
         commercetoolsSdkJvm: '1.25.0',
         fluentHc: '4.5.1',
-        guava: '19.0',
+        guava: '23.0',
         hamcrest: '1.3',
         jUnit: '4.12',
         assertJ: '3.8.0',
@@ -247,7 +247,10 @@ project(":functionaltests") {
         testImplementation 'org.concordion:concordion:1.5.1'
         testImplementation 'org.concordion:concordion-input-style-extension:0.1'
         testImplementation 'org.concordion:concordion-run-totals-extension:1.0.0'
-        testImplementation 'org.concordion:concordion-parallel-run-extension:1.0.1'
+        testImplementation ('org.concordion:concordion-parallel-run-extension:1.0.1') {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+
         testImplementation 'org.seleniumhq.selenium:selenium-java:2.53.1'
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ def depVersions = [
         slf4jLogbackClassic: '1.2.3',
         slf4jLog4j: '1.7.25',
         unirest: '1.4.9',
-        hamcrestDate: '2.0.4',
         mockito: '1.10.19'
 ]
 
@@ -81,7 +80,6 @@ project(":service") {
         implementation 'org.quartz-scheduler:quartz:2.2.2'
 
         testImplementation "org.assertj:assertj-core:${depVersions.assertJ}"
-        testImplementation "org.exparity:hamcrest-date:${depVersions.hamcrestDate}"
         testImplementation "org.mockito:mockito-core:${depVersions.mockito}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ def depVersions = [
 
 allprojects {
     group = 'com.commercetools'
-    version = '2.1.0' // this version is used in shadowJar.manifest.Implementation-Version and then at runtime as getImplementationVersion()
+    version = '2.2.0-dev' // this version is used in shadowJar.manifest.Implementation-Version and then at runtime as getImplementationVersion()
 
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"

--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,14 @@ def depVersions = [
         mockito: '1.10.19',
 
         // : functionaltests
-        fluentHc: '4.5.3',
-        slf4jLog4j: '1.7.25',
-        seleniumJava: '3.6.0',
-        seleniumHtmlunitDriver: '2.52.0',
         concordion: '1.5.1',
         concordionInputStyleExtension: '0.1',
         concordionConcordionRunTotalsExtension: '1.0.0',
-        concordionParallelRunExtension: '1.0.1'
+        concordionParallelRunExtension: '1.0.1',
+        seleniumJava: '3.6.0',
+        seleniumHtmlunitDriver: '2.27',
+        fluentHc: '4.5.3',
+        slf4jLog4j: '1.7.25'
 
 ]
 
@@ -257,12 +257,12 @@ project(":functionaltests") {
         }
 
         testImplementation "org.seleniumhq.selenium:selenium-java:${depVersions.seleniumJava}"
-        testImplementation "org.seleniumhq.selenium:selenium-htmlunit-driver:${depVersions.seleniumHtmlunitDriver}"
+        testImplementation "org.seleniumhq.selenium:htmlunit-driver:${depVersions.seleniumHtmlunitDriver}"
+
+        testImplementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings
         testImplementation "org.slf4j:log4j-over-slf4j:${depVersions.slf4jLog4j}"
-
-        testImplementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
     }
 
     compileJava.dependsOn ':service:jar'

--- a/build.gradle
+++ b/build.gradle
@@ -13,20 +13,30 @@ plugins {
 }
 
 def depVersions = [
+        //all
         commercetoolsSdkJvm: '1.25.0',
-        sparkCore: '2.6.0',
-        fluentHc: '4.5.3',
         guava: '23.0',
-        quartz: '2.3.0',
-        hamcrest: '1.3',
-        jUnit: '4.12',
-        assertJ: '3.8.0',
         slf4jLogbackClassic: '1.2.3',
-        slf4jLog4j: '1.7.25',
         unirest: '1.4.9',
+
+        // :service
+        sparkCore: '2.6.0',
+        quartz: '2.3.0',
+        jUnit: '4.12',
+        hamcrest: '1.3',
+        assertJ: '3.8.0',
         mockito: '1.10.19',
+
+        // : functionaltests
+        fluentHc: '4.5.3',
+        slf4jLog4j: '1.7.25',
         seleniumJava: '3.6.0',
-        seleniumHtmlunitDriver: '2.52.0'
+        seleniumHtmlunitDriver: '2.52.0',
+        concordion: '1.5.1',
+        concordionInputStyleExtension: '0.1',
+        concordionConcordionRunTotalsExtension: '1.0.0',
+        concordionParallelRunExtension: '1.0.1'
+
 ]
 
 allprojects {
@@ -239,10 +249,10 @@ project(":functionaltests") {
     dependencies {
         testImplementation project(":service")
 
-        testImplementation 'org.concordion:concordion:1.5.1'
-        testImplementation 'org.concordion:concordion-input-style-extension:0.1'
-        testImplementation 'org.concordion:concordion-run-totals-extension:1.0.0'
-        testImplementation ('org.concordion:concordion-parallel-run-extension:1.0.1') {
+        testImplementation "org.concordion:concordion:${depVersions.concordion}"
+        testImplementation "org.concordion:concordion-input-style-extension:${depVersions.concordionInputStyleExtension}"
+        testImplementation "org.concordion:concordion-run-totals-extension:${depVersions.concordionConcordionRunTotalsExtension}"
+        testImplementation ("org.concordion:concordion-parallel-run-extension:${depVersions.concordionParallelRunExtension}") {
             exclude group: 'com.google.guava', module: 'guava'
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ project(":service") {
     mainClassName = 'com.commercetools.Main'
 
     dependencies {
-        implementation 'com.neovisionaries:nv-i18n:1.17'
         implementation('com.sparkjava:spark-core:2.5.4') {
             exclude group: 'org.slf4j', module: 'slf4j-simple'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -51,9 +51,7 @@ subprojects {
 
     dependencies {
         implementation "com.google.guava:guava:${depVersions.guava}"
-        implementation ("com.commercetools.sdk.jvm.core:commercetools-java-client:${depVersions.commercetoolsSdkJvm}") {
-            exclude group: 'org.assertj'
-        }
+        implementation "com.commercetools.sdk.jvm.core:commercetools-java-client:${depVersions.commercetoolsSdkJvm}"
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:${depVersions.commercetoolsSdkJvm}"
         implementation "ch.qos.logback:logback-classic:${depVersions.slf4jLogbackClassic}"
         implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,8 @@ def depVersions = [
         guava: '19.0',
         hamcrest: '1.3',
         jUnit: '4.12',
-        moneta: '1.0',
+        assertJ: '3.8.0',
+        moneta: '1.1',
         slf4jLogbackClassic: '1.2.2',
         slf4jLog4j: '1.7.25'
 ]
@@ -43,15 +44,18 @@ subprojects {
     }
 
     dependencies {
-        compile "com.google.guava:guava:$depVersions.guava"
-        compile "com.commercetools.sdk.jvm.core:commercetools-java-client:$depVersions.commercetoolsSdkJvm"
-        compile "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
-        compile "org.javamoney:moneta:$depVersions.moneta"
-        compile "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
+        implementation "com.google.guava:guava:$depVersions.guava"
+        implementation ("com.commercetools.sdk.jvm.core:commercetools-java-client:$depVersions.commercetoolsSdkJvm") {
+            exclude group: 'org.assertj'
+        }
+        implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
+        implementation "org.javamoney:moneta:$depVersions.moneta"
+        implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
+        implementation "org.assertj:assertj-core:${depVersions.assertJ}"
 
-        testCompile "junit:junit:$depVersions.jUnit"
-        testCompile "org.hamcrest:hamcrest-core:$depVersions.hamcrest"
-        testCompile "org.hamcrest:hamcrest-library:$depVersions.hamcrest"
+        testImplementation "junit:junit:$depVersions.jUnit"
+        testImplementation "org.hamcrest:hamcrest-core:$depVersions.hamcrest"
+        testImplementation "org.hamcrest:hamcrest-library:$depVersions.hamcrest"
     }
 
 }
@@ -68,17 +72,17 @@ project(":service") {
     mainClassName = 'com.commercetools.Main'
 
     dependencies {
-        compile 'com.mashape.unirest:unirest-java:1.4.7'
-        compile 'com.neovisionaries:nv-i18n:1.17'
-        compile('com.sparkjava:spark-core:2.5.4') {
+        implementation 'com.mashape.unirest:unirest-java:1.4.7'
+        implementation 'com.neovisionaries:nv-i18n:1.17'
+        implementation('com.sparkjava:spark-core:2.5.4') {
             exclude group: 'org.slf4j', module: 'slf4j-simple'
         }
-        compile 'org.apache.httpcomponents:fluent-hc:4.5.1'
-        compile 'org.quartz-scheduler:quartz:2.2.2'
+        implementation 'org.apache.httpcomponents:fluent-hc:4.5.1'
+        implementation 'org.quartz-scheduler:quartz:2.2.2'
 
-        testCompile 'org.assertj:assertj-core:3.3.0'
-        testCompile 'org.exparity:hamcrest-date:2.0.1'
-        testCompile 'org.mockito:mockito-core:1.10.19'
+        testImplementation "org.assertj:assertj-core:${depVersions.assertJ}"
+        testImplementation 'org.exparity:hamcrest-date:2.0.1'
+        testImplementation 'org.mockito:mockito-core:1.10.19'
     }
 
     shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ subprojects {
         }
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:$depVersions.commercetoolsSdkJvm"
         implementation "ch.qos.logback:logback-classic:$depVersions.slf4jLogbackClassic"
-        implementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
         implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"
 
         testImplementation "junit:junit:$depVersions.jUnit"
@@ -251,6 +250,8 @@ project(":functionaltests") {
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings
         testImplementation "org.slf4j:log4j-over-slf4j:$depVersions.slf4jLog4j"
+
+        testImplementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
     }
 
     compileJava.dependsOn ':service:jar'

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ subprojects {
         implementation "com.mashape.unirest:unirest-java:${depVersions.unirest}"
 
         testImplementation "junit:junit:$depVersions.jUnit"
-        testImplementation "org.hamcrest:hamcrest-core:$depVersions.hamcrest"
         testImplementation "org.hamcrest:hamcrest-library:$depVersions.hamcrest"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -259,6 +259,7 @@ project(":functionaltests") {
         testImplementation "org.seleniumhq.selenium:selenium-java:${depVersions.seleniumJava}"
         testImplementation "org.seleniumhq.selenium:htmlunit-driver:${depVersions.seleniumHtmlunitDriver}"
 
+        // TODO: remove the dependency and use HttpClientBuilder.create().build().execute(), see #185
         testImplementation "org.apache.httpcomponents:fluent-hc:${depVersions.fluentHc}"
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 def depVersions = [
         commercetoolsSdkJvm: '1.25.0',
-        fluentHc: '4.5.1',
+        fluentHc: '4.5.3',
         guava: '23.0',
         hamcrest: '1.3',
         jUnit: '4.12',

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ def depVersions = [
         slf4jLogbackClassic: '1.2.3',
         slf4jLog4j: '1.7.25',
         unirest: '1.4.9',
-        mockito: '1.10.19'
+        mockito: '1.10.19',
+        seleniumJava: '3.6.0',
+        seleniumHtmlunitDriver: '2.52.0'
 ]
 
 allprojects {
@@ -246,7 +248,8 @@ project(":functionaltests") {
             exclude group: 'com.google.guava', module: 'guava'
         }
 
-        testImplementation 'org.seleniumhq.selenium:selenium-java:2.53.1'
+        testImplementation "org.seleniumhq.selenium:selenium-java:${depVersions.seleniumJava}"
+        testImplementation "org.seleniumhq.selenium:selenium-htmlunit-driver:${depVersions.seleniumHtmlunitDriver}"
 
         // the selenium dependency above has default Log4j logger, thus we have to bridge it to our slf4j settings
         testImplementation "org.slf4j:log4j-over-slf4j:${depVersions.slf4jLog4j}"

--- a/docs/Field-Mapping.md
+++ b/docs/Field-Mapping.md
@@ -84,10 +84,7 @@ WORK IN PROGRESS (only active calls to PO here, no status notifications yet)
 | interfaceId | `txid` | PAYONE |  |
 | amountPlanned.centAmount | - | CT | Initially set by checkout and not modified any more. `price` from PAYONE notifications is only checked against the matching transaction amount, not the overall goal described in amountPlanned. |
 | amountPlanned.currency | - | CT |  |
-| amountAuthorized.centAmount | `amount` | CT / PAYONE | ONLY on CREDIT_CARD payments: Once the Authorization Transaction is in status "Success", copy the amount here.  |
 | authorizedUntil | - | PAYONE | credit card payments are treated as valid seven days after the `txtime` value of the `preauthorization` call (not of other transactions!), but that is not a guarantee. Therefore it was chosen to better leave this field empty.  |
-| amountPaid.centAmount | `receivable` minus `balance` | PAYONE | only if both parameters available |
-| amountRefunded.centAmount | (from transactions) | PAYONE | (Sum of successful Refund Transactions) |
 | paymentMethodInfo.paymentInterface | - | CT | Must be "PAYONE" in CT, otherwise do not handle the Payment at all |
 | paymentMethodInfo.method | - | CT | (see the method mapping table above) |
 | paymentMethodInfo.name.{locale} | - | - | (not passed, project specific content) |
@@ -380,10 +377,6 @@ The matching transaction is found by sequencenumber = interactionId.
 | `vsettlement` | not set or `completed` | `7.5` | (unsupported) | (unsupported) | only available with PAYONE Billing module, must be activated |
 | `invoice` | not set or `completed` | `7.5` | (nothing) | (nothing) | no status change, just write the invoice ID / URL |
 | `failed` | not set or `completed` | `7.5` | (unsupported)  | (unsupported) | (not fully implemented at PAYONE yet) |
-
-Additional fields to be updated in any case:
- * amountPaid
- * amountRefunded
 
 # Unused / unsupported PAYONE fields & features
 

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -85,4 +85,17 @@ You have to change the payment handling URL:
     (like <code>**MERCHANT1**/commercetools/handle/payments/</code>)
 
 
-TO be continued....
+## Migrating from v2.1.0 to v2.2.0 (Multitenancy)
+
+  1. `Initial` state should be explicitly used as default transaction state now. 
+      
+      See [issue #175](https://github.com/commercetools/commercetools-payone-integration/pull/175) 
+      
+      See [Release Notes](http://dev.commercetools.com/release-notes.html#release-notes---commercetools-platform---version-release-29-september-2017)
+      
+      See [Transaction States](https://dev.commercetools.com/http-api-projects-payments.html#transactionstate) documentation
+  
+  1. All references and update actions for `amountAuthorized`, `amountPaid` and `amountRefunded` are removed 
+  since they are deprecated. The service consumers should not rely on them any more.  
+  
+      See [Release Notes](http://dev.commercetools.com/release-notes.html#release-notes---commercetools-platform---version-release-29-september-2017)

--- a/functionaltests/src/test/java/specs/BaseFixture.java
+++ b/functionaltests/src/test/java/specs/BaseFixture.java
@@ -17,6 +17,7 @@ import com.neovisionaries.i18n.CountryCode;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.carts.CartDraft;
 import io.sphere.sdk.carts.CartDraftBuilder;
+import io.sphere.sdk.carts.LineItemDraft;
 import io.sphere.sdk.carts.commands.CartCreateCommand;
 import io.sphere.sdk.carts.commands.CartUpdateCommand;
 import io.sphere.sdk.carts.commands.updateactions.AddLineItem;
@@ -244,7 +245,7 @@ public abstract class BaseFixture {
                 ctpClient().executeBlocking(CartCreateCommand.of(cardDraft)),
                 ImmutableList.of(
                         AddPayment.of(payment),
-                        AddLineItem.of(product.getId(), product.getMasterData().getCurrent().getMasterVariant().getId(), 1),
+                        AddLineItem.of(LineItemDraft.of(product.getId(), product.getMasterData().getCurrent().getMasterVariant().getId(), 1)),
                         SetShippingAddress.of(Address.of(CountryCode.DE)),
                         SetBillingAddress.of(Address.of(CountryCode.DE).withLastName(buyerLastName))
                 )));

--- a/functionaltests/src/test/java/specs/paymentmethods/BaseNotifiablePaymentFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/BaseNotifiablePaymentFixture.java
@@ -7,13 +7,10 @@ import io.sphere.sdk.payments.Payment;
 import org.concordion.api.MultiValueResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import specs.BaseFixture;
 import specs.NotificationTimeoutWaiter;
 import specs.response.BasePaymentFixture;
 
-import javax.money.format.MonetaryFormats;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -88,7 +85,6 @@ public class BaseNotifiablePaymentFixture extends BasePaymentFixture {
      * @param txaction current txAction to wait (paid)
      * @param prevTxaction previous txAction which must be successful
      * @return <b>true</b> if previous and current txactions completed successfully.
-     * @throws Exception
      */
     public boolean receivedNextNotificationOfActionFor(final String paymentNames, final String txaction,
                                                           final String prevTxaction) throws Exception {
@@ -124,20 +120,11 @@ public class BaseNotifiablePaymentFixture extends BasePaymentFixture {
         final long paidNotificationCount = getTotalNotificationCountOfAction(payment, "paid");
 
         final String transactionId = getIdOfLastTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
 
         return ImmutableMap.<String, String> builder()
                 .put("appointedNotificationCount", Long.toString(appointedNotificationCount))
                 .put("paidNotificationCount", Long.toString(paidNotificationCount))
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("version", payment.getVersion().toString())
                 .build();
     }
@@ -148,14 +135,9 @@ public class BaseNotifiablePaymentFixture extends BasePaymentFixture {
         long appointedNotificationCount = getTotalNotificationCountOfAction(payment, txaction);
 
         final String transactionId = getIdOfLastTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-
         return MultiValueResult.multiValueResult()
                 .with("notificationCount", Long.toString(appointedNotificationCount))
                 .with("transactionState", getTransactionState(payment, transactionId))
-                .with("amountAuthorized", amountAuthorized)
                 .with("version", payment.getVersion().toString());
     }
 

--- a/functionaltests/src/test/java/specs/paymentmethods/cashinadvance/CustomerPaymentFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/cashinadvance/CustomerPaymentFixture.java
@@ -39,19 +39,11 @@ public class CustomerPaymentFixture extends BaseNotifiablePaymentFixture {
         final HttpResponse response = requestToHandlePaymentByLegibleName(paymentName);
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfFirstTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null)
-                ? MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized())
-                : BaseFixture.EMPTY_STRING;
-        final String amountPaid = (payment.getAmountPaid() != null)
-                ? MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid())
-                : BaseFixture.EMPTY_STRING;
 
         return ImmutableMap.<String, String>builder()
                 .put("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .put("interactionCount", getInteractionRequestCountOverAllTransactions(payment, requestType))
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("version", payment.getVersion().toString()).build();
     }
 
@@ -83,18 +75,8 @@ public class CustomerPaymentFixture extends BaseNotifiablePaymentFixture {
                 getTotalNotificationCountOfAction(payment, "appointed");
         final long paidNotificationCount = getTotalNotificationCountOfAction(payment, "paid");
 
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
-
         return ImmutableMap.<String, String>builder()
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("appointedNotificationCount", String.valueOf(appointedNotificationCount))
                 .put("paidNotificationCount", String.valueOf(paidNotificationCount))
                 .put("version", payment.getVersion().toString())

--- a/functionaltests/src/test/java/specs/paymentmethods/cashinadvance/PreauthorizationFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/cashinadvance/PreauthorizationFixture.java
@@ -5,12 +5,9 @@ import io.sphere.sdk.payments.Payment;
 import org.apache.http.HttpResponse;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
-import specs.BaseFixture;
 import specs.response.BasePaymentFixture;
 
-import javax.money.format.MonetaryFormats;
 import java.io.IOException;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -40,19 +37,11 @@ public class PreauthorizationFixture extends BasePaymentFixture {
         final HttpResponse response = requestToHandlePaymentByLegibleName(paymentName);
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfFirstTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null)
-                ? MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized())
-                : BaseFixture.EMPTY_STRING;
-        final String amountPaid = (payment.getAmountPaid() != null)
-                ? MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid())
-                : BaseFixture.EMPTY_STRING;
 
         return ImmutableMap.<String, String>builder()
                 .put("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .put("interactionCount", getInteractionRequestCountOverAllTransactions(payment, requestType))
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("version", payment.getVersion().toString()).build();
     }
 

--- a/functionaltests/src/test/java/specs/paymentmethods/creditcard/AuthorizationWith3dsFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/creditcard/AuthorizationWith3dsFixture.java
@@ -19,12 +19,10 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import specs.BaseFixture;
 import specs.paymentmethods.BaseNotifiablePaymentFixture;
 import util.WebDriver3ds;
 
 import javax.money.MonetaryAmount;
-import javax.money.format.MonetaryFormats;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -169,14 +167,9 @@ public class AuthorizationWith3dsFixture extends BaseNotifiablePaymentFixture {
         final Payment updatedPayment = fetchPaymentById(payment.getId());
         final long appointedNotificationCount = getTotalNotificationCountOfAction(updatedPayment, txAction);
 
-        final String amountAuthorized = (updatedPayment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(updatedPayment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-
         return ImmutableMap.<String, String> builder()
                 .put("appointedNotificationCount", String.valueOf(appointedNotificationCount))
                 .put("transactionState", getTransactionState(updatedPayment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
                 .put("version", updatedPayment.getVersion().toString())
                 .build();
     }

--- a/functionaltests/src/test/java/specs/paymentmethods/creditcard/AuthorizationWithout3dsFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/creditcard/AuthorizationWithout3dsFixture.java
@@ -16,11 +16,9 @@ import org.apache.http.HttpResponse;
 import org.concordion.api.MultiValueResult;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
-import specs.BaseFixture;
 import specs.paymentmethods.BaseNotifiablePaymentFixture;
 
 import javax.money.MonetaryAmount;
-import javax.money.format.MonetaryFormats;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.Locale;
@@ -83,15 +81,10 @@ public class AuthorizationWithout3dsFixture extends BaseNotifiablePaymentFixture
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfLastTransaction(payment);
 
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-
         return MultiValueResult.multiValueResult()
                 .with("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .with("interactionCount", getInteractionRequestCount(payment, transactionId, requestType))
                 .with("transactionState", getTransactionState(payment, transactionId))
-                .with("amountAuthorized", amountAuthorized)
                 .with("version", payment.getVersion().toString());
     }
 

--- a/functionaltests/src/test/java/specs/paymentmethods/creditcard/BaseCreditCardChargeFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/creditcard/BaseCreditCardChargeFixture.java
@@ -3,11 +3,7 @@ package specs.paymentmethods.creditcard;
 import io.sphere.sdk.payments.Payment;
 import org.apache.http.HttpResponse;
 import org.concordion.api.MultiValueResult;
-import specs.BaseFixture;
 import specs.paymentmethods.BaseNotifiablePaymentFixture;
-
-import javax.money.format.MonetaryFormats;
-import java.util.Locale;
 
 abstract public class BaseCreditCardChargeFixture extends BaseNotifiablePaymentFixture {
 
@@ -16,19 +12,11 @@ abstract public class BaseCreditCardChargeFixture extends BaseNotifiablePaymentF
         final HttpResponse response = requestToHandlePaymentByLegibleName(paymentName);
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfLastTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
 
         return MultiValueResult.multiValueResult()
                 .with("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .with("interactionCount", getInteractionRequestCount(payment, transactionId, requestType))
                 .with("transactionState", getTransactionState(payment, transactionId))
-                .with("amountAuthorized", amountAuthorized)
-                .with("amountPaid", amountPaid)
                 .with("version", payment.getVersion().toString());
     }
 }

--- a/functionaltests/src/test/java/specs/paymentmethods/creditcard/ChargeImmediatelyWith3dsFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/creditcard/ChargeImmediatelyWith3dsFixture.java
@@ -17,11 +17,9 @@ import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
-import specs.BaseFixture;
 import util.WebDriver3ds;
 
 import javax.money.MonetaryAmount;
-import javax.money.format.MonetaryFormats;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.time.ZonedDateTime;
@@ -122,19 +120,9 @@ public class ChargeImmediatelyWith3dsFixture extends BaseCreditCardChargeFixture
         final long appointedNotificationCount = getTotalNotificationCountOfAction(payment, "appointed");
         final long paidNotificationCount = getTotalNotificationCountOfAction(payment, "paid");
 
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                NULL_STRING;
-
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
-
         return ImmutableMap.<String, String>builder()
                 .put("transactionState", getTransactionState(payment, transactionId))
                 .put("responseRedirectUrl", responseRedirectUrl.substring(0, urlTrimAt))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("successUrl", successUrlForPayment.getOrDefault(paymentName, EMPTY_STRING))
                 .put("appointedNotificationCount", String.valueOf(appointedNotificationCount))
                 .put("paidNotificationCount", String.valueOf(paidNotificationCount))

--- a/functionaltests/src/test/java/specs/paymentmethods/creditcard/ChargePreauthorizedFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/creditcard/ChargePreauthorizedFixture.java
@@ -8,6 +8,7 @@ import com.neovisionaries.i18n.CountryCode;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.carts.CartDraft;
 import io.sphere.sdk.carts.CartDraftBuilder;
+import io.sphere.sdk.carts.LineItemDraft;
 import io.sphere.sdk.carts.commands.CartCreateCommand;
 import io.sphere.sdk.carts.commands.CartUpdateCommand;
 import io.sphere.sdk.carts.commands.updateactions.AddLineItem;
@@ -121,7 +122,7 @@ public class ChargePreauthorizedFixture extends BaseFixture {
                  ctpClient.executeBlocking(CartCreateCommand.of(cardDraft)),
                  ImmutableList.of(
                          AddPayment.of(payment),
-                         AddLineItem.of(product.getId(), product.getMasterData().getCurrent().getMasterVariant().getId(), 1),
+                         AddLineItem.of(LineItemDraft.of(product.getId(), product.getMasterData().getCurrent().getMasterVariant().getId(), 1)),
                          SetShippingAddress.of(Address.of(CountryCode.DE)),
                          SetBillingAddress.of(Address.of(CountryCode.DE).withLastName("Test Buyer"))
                  )));

--- a/functionaltests/src/test/java/specs/paymentmethods/paypal/ChargeImmediatelyFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/paypal/ChargeImmediatelyFixture.java
@@ -18,7 +18,6 @@ import org.junit.runner.RunWith;
 import specs.BaseFixture;
 
 import javax.money.MonetaryAmount;
-import javax.money.format.MonetaryFormats;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -94,19 +93,11 @@ public class ChargeImmediatelyFixture extends BaseFixture {
         final HttpResponse response = requestToHandlePaymentByLegibleName(paymentName);
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfFirstTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
 
         return ImmutableMap.<String, String> builder()
                 .put("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .put("interactionCount", getInteractionRequestCountOverAllTransactions(payment, requestType))
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("version", payment.getVersion().toString())
                 .build();
     }
@@ -128,20 +119,10 @@ public class ChargeImmediatelyFixture extends BaseFixture {
 
         final long paidNotificationCount = getTotalNotificationCountOfAction(payment, "paid");
 
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                NULL_STRING;
-
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
-
         return ImmutableMap.<String, String>builder()
                 .put("transactionState", getTransactionState(payment, transactionId))
                 .put("responseRedirectUrlStart", responseRedirectUrl.substring(0, urlTrimAt))
                 .put("responseRedirectUrlFull", responseRedirectUrl)
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("appointedNotificationCount", String.valueOf(appointedNotificationCount))
                 .put("paidNotificationCount", String.valueOf(paidNotificationCount))
                 .put("version", payment.getVersion().toString())

--- a/functionaltests/src/test/java/specs/paymentmethods/postfinance/ChargeImmediatelyFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/postfinance/ChargeImmediatelyFixture.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import specs.BaseFixture;
 
 import javax.money.MonetaryAmount;
-import javax.money.format.MonetaryFormats;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.time.ZonedDateTime;
@@ -102,19 +101,11 @@ public class ChargeImmediatelyFixture extends BaseFixture {
         final HttpResponse response = requestToHandlePaymentByLegibleName(paymentName);
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfFirstTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
 
         return ImmutableMap.<String, String> builder()
                 .put("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .put("interactionCount", getInteractionRequestCountOverAllTransactions(payment, requestType))
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("version", payment.getVersion().toString())
                 .build();
     }

--- a/functionaltests/src/test/java/specs/paymentmethods/sofortueberweisung/ChargeImmediatelyFixture.java
+++ b/functionaltests/src/test/java/specs/paymentmethods/sofortueberweisung/ChargeImmediatelyFixture.java
@@ -20,12 +20,10 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import specs.BaseFixture;
 import specs.paymentmethods.BaseNotifiablePaymentFixture;
 import util.WebDriverSofortueberweisung;
 
 import javax.money.MonetaryAmount;
-import javax.money.format.MonetaryFormats;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.time.ZonedDateTime;
@@ -118,19 +116,11 @@ public class ChargeImmediatelyFixture extends BaseNotifiablePaymentFixture {
         final HttpResponse response = requestToHandlePaymentByLegibleName(paymentName);
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfFirstTransaction(payment);
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
 
         return ImmutableMap.<String, String>builder()
                 .put("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .put("interactionCount", getInteractionRequestCountOverAllTransactions(payment, requestType))
                 .put("transactionState", getTransactionState(payment, transactionId))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("version", payment.getVersion().toString())
                 .build();
     }
@@ -151,20 +141,10 @@ public class ChargeImmediatelyFixture extends BaseNotifiablePaymentFixture {
                 getTotalNotificationCountOfAction(payment, "appointed");
         final long paidNotificationCount = getTotalNotificationCountOfAction(payment, "paid");
 
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                NULL_STRING;
-
-        final String amountPaid = (payment.getAmountPaid() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountPaid()) :
-                BaseFixture.EMPTY_STRING;
-
         return ImmutableMap.<String, String>builder()
                 .put("transactionState", getTransactionState(payment, transactionId))
                 .put("responseRedirectUrlStart", responseRedirectUrl.substring(0, urlTrimAt))
                 .put("successUrl", successUrlForPayment.getOrDefault(paymentName, EMPTY_STRING))
-                .put("amountAuthorized", amountAuthorized)
-                .put("amountPaid", amountPaid)
                 .put("appointedNotificationCount", String.valueOf(appointedNotificationCount))
                 .put("paidNotificationCount", String.valueOf(paidNotificationCount))
                 .put("version", payment.getVersion().toString())

--- a/functionaltests/src/test/java/specs/service/OrderServiceImplFixture.java
+++ b/functionaltests/src/test/java/specs/service/OrderServiceImplFixture.java
@@ -26,7 +26,6 @@ import specs.BaseFixture;
 import javax.money.CurrencyUnit;
 import javax.money.MonetaryAmount;
 import javax.money.NumberValue;
-import javax.money.format.MonetaryFormats;
 import java.time.ZonedDateTime;
 import java.util.Locale;
 import java.util.Optional;
@@ -98,16 +97,11 @@ public class OrderServiceImplFixture extends BaseFixture {
         final Payment payment = fetchPaymentByLegibleName(paymentName);
         final String transactionId = getIdOfLastTransaction(payment);
 
-        final String amountAuthorized = (payment.getAmountAuthorized() != null) ?
-                MonetaryFormats.getAmountFormat(Locale.GERMANY).format(payment.getAmountAuthorized()) :
-                BaseFixture.EMPTY_STRING;
-
         Optional<Order> order = executeBlocking(orderService.getOrderByPaymentId(payment.getId()));
 
         return MultiValueResult.multiValueResult()
                 .with("statusCode", Integer.toString(response.getStatusLine().getStatusCode()))
                 .with("transactionState", getTransactionState(payment, transactionId))
-                .with("amountAuthorized", amountAuthorized)
                 .with("centAmount", order.map(Order::getTotalPrice).map(MonetaryAmount::getNumber).map(NumberValue::intValue).orElse(-666))
                 .with("currencyCode", order.map(Order::getTotalPrice).map(MonetaryAmount::getCurrency).map(CurrencyUnit::getCurrencyCode).orElse("ERR"))
                 .with("paymentState", order.map(Order::getPaymentState).map(PaymentState::toString).orElse(null));

--- a/functionaltests/src/test/java/specs/service/PaymentServiceFixture.java
+++ b/functionaltests/src/test/java/specs/service/PaymentServiceFixture.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.updateactions.AddInterfaceInteraction;
-import io.sphere.sdk.payments.commands.updateactions.SetAmountPaid;
 import io.sphere.sdk.payments.commands.updateactions.SetStatusInterfaceCode;
 import io.sphere.sdk.payments.commands.updateactions.SetStatusInterfaceText;
 import io.sphere.sdk.types.CustomFields;
@@ -136,8 +135,7 @@ public class PaymentServiceFixture extends BaseFixture {
      * Test {@link PaymentService#updatePayment(io.sphere.sdk.payments.Payment, java.util.List)}
      */
     public MultiValueResult updatePayment(String paymentName, String statusCode, String statusText,
-                                          String sequenceNumber, String txAction, String notificationText,
-                                          long paidCentAmount, String currencyCode) {
+                                          String sequenceNumber, String txAction, String notificationText) {
         final Payment payment = fetchPaymentByLegibleName(paymentName);
 
         ImmutableList<UpdateAction<Payment>> actions = ImmutableList.of(
@@ -149,8 +147,7 @@ public class PaymentServiceFixture extends BaseFixture {
                                 TIMESTAMP_FIELD, ZonedDateTime.now(),
                                 SEQUENCE_NUMBER_FIELD, sequenceNumber,
                                 TX_ACTION_FIELD, txAction,
-                                NOTIFICATION_FIELD, notificationText)),
-                SetAmountPaid.of(createMonetaryAmountFromCent(paidCentAmount, currencyCode)));
+                                NOTIFICATION_FIELD, notificationText)));
 
         Payment updatedPayment = executeBlocking(paymentService.updatePayment(payment, actions));
 
@@ -159,13 +156,12 @@ public class PaymentServiceFixture extends BaseFixture {
     }
 
     /**
-     * Test the previous call of {@link #updatePayment(String, String, String, String, String, String, long, String)}
+     * Test the previous call of {@link #updatePayment(String, String, String, String, String, String)}
      * was successful.
      *
      * @param paymentName            test specific unique payment name
      * @param paymentMethodInterface payment provider name, like PAYONE
-     * @return set of the same values as set in the {@link #updatePayment(String, String, String, String, String, String, long, String)},
-     *         except the paid amount is set as formatted string.
+     * @return set of the same values as set in the {@link #updatePayment(String, String, String, String, String, String)}
      */
     public MultiValueResult verifyUpdatedPayment(String paymentName, String paymentMethodInterface) {
         final String interfaceId = paymentNameToOrderNumberMap.get(paymentName);
@@ -184,8 +180,7 @@ public class PaymentServiceFixture extends BaseFixture {
                 .with("statusText", payment.getPaymentStatus().getInterfaceText())
                 .with("sequenceNumber", interfaceInteractions.getFieldAsString(SEQUENCE_NUMBER_FIELD))
                 .with("txAction", interfaceInteractions.getFieldAsString(TX_ACTION_FIELD))
-                .with("notificationText", interfaceInteractions.getFieldAsString(NOTIFICATION_FIELD))
-                .with("paid", currencyFormatterDe.format(payment.getAmountPaid()));
+                .with("notificationText", interfaceInteractions.getFieldAsString(NOTIFICATION_FIELD));
     }
 
 

--- a/functionaltests/src/test/java/util/WebDriver3ds.java
+++ b/functionaltests/src/test/java/util/WebDriver3ds.java
@@ -28,7 +28,7 @@ public class WebDriver3ds extends HtmlUnitDriver {
     private static final int DEFAULT_TIMEOUT = 5;
 
     public WebDriver3ds() {
-        super(BrowserVersion.FIREFOX_45, true);
+        super(BrowserVersion.CHROME, true);
 
         final Timeouts timeouts = manage().timeouts();
         timeouts.implicitlyWait(DEFAULT_TIMEOUT, TimeUnit.SECONDS);

--- a/functionaltests/src/test/java/util/WebDriverSofortueberweisung.java
+++ b/functionaltests/src/test/java/util/WebDriverSofortueberweisung.java
@@ -28,7 +28,7 @@ public class WebDriverSofortueberweisung extends HtmlUnitDriver {
     private static final int DEFAULT_TIMEOUT = 5;
 
     public WebDriverSofortueberweisung() {
-        super(BrowserVersion.FIREFOX_45, true);
+        super(BrowserVersion.CHROME, true);
 
         final Timeouts timeouts = manage().timeouts();
         timeouts.implicitlyWait(DEFAULT_TIMEOUT, TimeUnit.SECONDS);

--- a/functionaltests/src/test/resources/specs/multitenancy/creditcard/ChargeImmediatelyWithout3ds2.html
+++ b/functionaltests/src/test/resources/specs/multitenancy/creditcard/ChargeImmediatelyWithout3ds2.html
@@ -109,8 +109,6 @@
                     <th c:assertEquals="#result.appointedNotificationCount">total # of <br/><em>appointed/completed</em> notifications</th>
                     <th c:assertEquals="#result.paidNotificationCount">total # of <br/><em>paid</em> notifications</th>
                     <th c:assertEquals="#result.transactionState">Charge <br/>Transaction State</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
-                    <th c:assertEquals="#result.amountPaid">Paid Amount</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
                 <tr>
@@ -118,8 +116,6 @@
                     <td>1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>32,10 EUR</td>
-                    <td>32,10 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -127,8 +123,6 @@
                     <td>1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>5,43 EUR</td>
-                    <td>5,43 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -136,8 +130,6 @@
                     <td>1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>34,56 EUR</td>
-                    <td>34,56 EUR</td>
                     <td></td>
                 </tr>
             </table>

--- a/functionaltests/src/test/resources/specs/paymentmethods/cashinadvance/CustomerPayment.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/cashinadvance/CustomerPayment.html
@@ -67,40 +67,30 @@
             <th c:set="#paymentName">Payment Name</th>
             <th c:assertEquals="#result.statusCode">Response <br />Status Code</th>
             <th c:assertEquals="#result.interactionCount">total # of <br /><em>authorization</em> requests sent</th>
-            <th c:assertEquals="#result.amountAuthorized">Amount Authorized</th>
-            <th c:assertEquals="#result.amountPaid">Amount Payed</th>
             <th c:assertEquals="#result.transactionState">Transaction State</th>
         </tr>
         <tr>
             <td class="inputvalue">Payment 1</td>
             <td class="success">200</td>
             <td class="success">0</td>
-            <td class="success"></td>
-            <td class="success"></td>
             <td class="success">Pending</td>
         </tr>
         <tr>
             <td class="inputvalue">Payment 2</td>
             <td class="success">200</td>
             <td class="success">0</td>
-            <td class="success"></td>
-            <td class="success"></td>
             <td class="success">Pending</td>
         </tr>
         <tr>
             <td class="inputvalue">Payment 3</td>
             <td class="success">200</td>
             <td class="success">0</td>
-            <td class="success"></td>
-            <td class="success"></td>
             <td class="success">Pending</td>
         </tr>
         <tr>
             <td class="inputvalue">Payment 4</td>
             <td class="success">200</td>
             <td class="success">0</td>
-            <td class="success"></td>
-            <td class="success"></td>
             <td class="success">Pending</td>
         </tr>
     </table>
@@ -121,40 +111,30 @@
             <th c:assertEquals="#result.transactionState">Transaction State</th>
             <th c:assertEquals="#result.appointedNotificationCount">total # of <br/><em>appointed/completed</em> notifications</th>
             <th c:assertEquals="#result.paidNotificationCount">total # of <br/><em>paid/completed</em> notifications</th>
-            <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
-            <th c:assertEquals="#result.amountPaid">Paid Amount</th>
         </tr>
         <tr>
             <td class="inputvalue">Payment 1</td>
             <td class="success">Success</td>
             <td class="success">1</td>
             <td class="success">1</td>
-            <td class="success"></td>
-            <td class="success">4,00 EUR</td>
         </tr>
         <tr>
             <td class="inputvalue">Payment 2</td>
             <td class="success">Pending</td>
             <td class="success">1</td>
             <td class="success">0</td>
-            <td class="success"></td>
-            <td class="success">3,80 EUR</td>
         </tr>
         <tr>
             <td class="inputvalue">Payment 3</td>
             <td class="success">Success</td>
             <td class="success">1</td>
             <td class="success">1</td>
-            <td class="success"></td>
-            <td class="success">4,20 EUR</td>
         </tr>
         <tr>
             <td class="inputvalue">Payment 4</td>
             <td class="success">Success</td>
             <td class="success">1</td>
             <td class="success">1</td>
-            <td class="success"></td>
-            <td class="success">4,00 EUR</td>
         </tr>
     </table>
 

--- a/functionaltests/src/test/resources/specs/paymentmethods/creditcard/AuthorizationWith3ds.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/creditcard/AuthorizationWith3ds.html
@@ -146,7 +146,6 @@
                     <th c:set="#paymentName">Payment Name</th>
                     <th c:assertEquals="#result.transactionState">Transaction State</th>
                     <th c:assertEquals="#result.appointedNotificationCount">total # of <em>appointed/completed</em> notifications</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
                     <th c:assertEquals="#result.successUrl">url called after successful verification</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
@@ -154,7 +153,6 @@
                     <td>Payment 1</td>
                     <td>Success</td>
                     <td>1</td>
-                    <td>5,02 EUR</td>
                     <td>[...]Payment+1+Success</td>
                     <td></td>
                 </tr>
@@ -162,7 +160,6 @@
                     <td>Payment 3</td>
                     <td>Success</td>
                     <td>1</td>
-                    <td>2.238,12 EUR</td>
                     <td>[...]Payment+3+Success</td>
                     <td></td>
                 </tr>
@@ -170,7 +167,6 @@
                     <td>Payment 4</td>
                     <td>Success</td>
                     <td>1</td>
-                    <td>39,21 EUR</td>
                     <td>[...]Payment+4+Success</td>
                     <td></td>
                 </tr>

--- a/functionaltests/src/test/resources/specs/paymentmethods/creditcard/AuthorizationWithout3ds.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/creditcard/AuthorizationWithout3ds.html
@@ -115,28 +115,24 @@
                     <th c:set="#paymentName">Payment Name</th>
                     <th c:assertEquals="#result.notificationCount">total # of <em>appointed/completed</em> notifications</th>
                     <th c:assertEquals="#result.transactionState">Transaction State</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
                 <tr>
                     <td>Payment 1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>20,00 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Payment 3</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>47,11 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Payment 4</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>2.707,13 EUR</td>
                     <td></td>
                 </tr>
             </table>
@@ -155,7 +151,6 @@
                     <th c:assertEquals="#result.statusCode">Response Status Code</th>
                     <th c:assertEquals="#result.interactionCount">total # of <em>preauthorization</em> requests sent</th>
                     <th c:assertEquals="#result.transactionState">Transaction State</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
                 <tr>
@@ -163,7 +158,6 @@
                     <td>200</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>20,00 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -172,14 +166,12 @@
                     <td>1</td>
                     <td>Failure</td>
                     <td></td>
-                    <td></td>
                 </tr>
                 <tr>
                     <td>Payment 3</td>
                     <td>200</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>47,11 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -187,7 +179,6 @@
                     <td>200</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>2.707,13 EUR</td>
                     <td></td>
                 </tr>
             </table>

--- a/functionaltests/src/test/resources/specs/paymentmethods/creditcard/ChargeImmediatelyWith3ds.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/creditcard/ChargeImmediatelyWith3ds.html
@@ -159,8 +159,6 @@
                     <th c:assertEquals="#result.transactionState">Transaction State</th>
                     <th c:assertEquals="#result.appointedNotificationCount">total # of <br/><em>appointed/completed</em> notifications</th>
                     <th c:assertEquals="#result.paidNotificationCount">total # of <br/><em>paid/completed</em> notifications</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
-                    <th c:assertEquals="#result.amountPaid">Paid Amount</th>
                     <th c:assertEquals="#result.successUrl">url called after successful verification</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
@@ -169,8 +167,6 @@
                     <td>Success</td>
                     <td>1</td>
                     <td>1</td>
-                    <td>null</td>
-                    <td>4,06 EUR</td>
                     <td>[...]Payment+1+Success</td>
                     <td></td>
                 </tr>
@@ -179,8 +175,6 @@
                     <td>Success</td>
                     <td>1</td>
                     <td>1</td>
-                    <td>null</td>
-                    <td>61,13 EUR</td>
                     <td>[...]Payment+3+Success</td>
                     <td></td>
                 </tr>
@@ -189,8 +183,6 @@
                     <td>Success</td>
                     <td>1</td>
                     <td>1</td>
-                    <td>null</td>
-                    <td>1.112,83 EUR</td>
                     <td>[...]Payment+4+Success</td>
                     <td></td>
                 </tr>

--- a/functionaltests/src/test/resources/specs/paymentmethods/creditcard/ChargeImmediatelyWithout3ds.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/creditcard/ChargeImmediatelyWithout3ds.html
@@ -119,8 +119,6 @@
                     <th c:assertEquals="#result.appointedNotificationCount">total # of <br/><em>appointed/completed</em> notifications</th>
                     <th c:assertEquals="#result.paidNotificationCount">total # of <br/><em>paid</em> notifications</th>
                     <th c:assertEquals="#result.transactionState">Charge <br/>Transaction State</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
-                    <th c:assertEquals="#result.amountPaid">Paid Amount</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
                 <tr>
@@ -128,8 +126,6 @@
                     <td>1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>32,10 EUR</td>
-                    <td>32,10 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -137,8 +133,6 @@
                     <td>1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>5,43 EUR</td>
-                    <td>5,43 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -146,8 +140,6 @@
                     <td>1</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>34,56 EUR</td>
-                    <td>34,56 EUR</td>
                     <td></td>
                 </tr>
             </table>
@@ -196,8 +188,6 @@
                     <th c:assertEquals="#result.statusCode">Response Status Code</th>
                     <th c:assertEquals="#result.interactionCount">total # of <br/><em>authorization</em> requests sent</th>
                     <th c:assertEquals="#result.transactionState">Transaction State</th>
-                    <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
-                    <th c:assertEquals="#result.amountPaid">Paid Amount</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
                 <tr>
@@ -205,8 +195,6 @@
                     <td>200</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>32,10 EUR</td>
-                    <td>32,10 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -215,16 +203,12 @@
                     <td>1</td>
                     <td>Failure</td>
                     <td></td>
-                    <td></td>
-                    <td></td>
                 </tr>
                 <tr>
                     <td>Payment 3</td>
                     <td>200</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>5,43 EUR</td>
-                    <td>5,43 EUR</td>
                     <td></td>
                 </tr>
                 <tr>
@@ -232,8 +216,6 @@
                     <td>200</td>
                     <td>1</td>
                     <td>Success</td>
-                    <td>34,56 EUR</td>
-                    <td>34,56 EUR</td>
                     <td></td>
                 </tr>
             </table>

--- a/functionaltests/src/test/resources/specs/paymentmethods/klarna/KlarnaRequest.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/klarna/KlarnaRequest.html
@@ -156,21 +156,18 @@
             <th c:set="#paymentName">Payment Name</th>
             <th c:assertEquals="#result.notificationCount">total # of <em>appointed/completed</em> notifications</th>
             <th c:assertEquals="#result.transactionState">Transaction State</th>
-            <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
             <th c:echo="#result.version">Version (for information only)</th>
-        </tr>§
+        </tr>
         <tr>
             <td>Payment 1</td>
             <td>1</td>
             <td>Success</td>
-            <td>591,90 EUR</td>
             <td></td>
         </tr>
         <tr>
             <td>Payment 2</td>
             <td>1</td>
             <td>Success</td>
-            <td>591,90 EUR</td>
             <td></td>
         </tr>
     </table>

--- a/functionaltests/src/test/resources/specs/paymentmethods/sofortueberweisung/ChargeImmediately.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/sofortueberweisung/ChargeImmediately.html
@@ -168,8 +168,6 @@
             <th c:assertEquals="#result.transactionState">Transaction State</th>
             <th c:assertEquals="#result.appointedNotificationCount">total # of <br/><em>appointed/completed</em> notifications</th>
             <th c:assertEquals="#result.paidNotificationCount">total # of <br/><em>paid/completed</em> notifications</th>
-            <th c:assertEquals="#result.amountAuthorized">Authorized Amount</th>
-            <th c:assertEquals="#result.amountPaid">Paid Amount</th>
             <th c:assertEquals="#result.successUrl">url called after successful verification</th>
             <th c:echo="#result.version">Version (for information only)</th>
         </tr>
@@ -178,8 +176,6 @@
             <td>Success</td>
             <td>1</td>
             <td>1</td>
-            <td>null</td>
-            <td>4,06 EUR</td>
             <td>[...]Payment-1-Success</td>
             <td></td>
         </tr>
@@ -188,8 +184,6 @@
             <td>Success</td>
             <td>1</td>
             <td>1</td>
-            <td>null</td>
-            <td>82,31 EUR</td>
             <td>[...]Payment-3-Success</td>
             <td></td>
         </tr>
@@ -198,8 +192,6 @@
             <td>Success</td>
             <td>1</td>
             <td>1</td>
-            <td>null</td>
-            <td>1.234,11 EUR</td>
             <td>[...]Payment-4-Success</td>
             <td></td>
         </tr>

--- a/functionaltests/src/test/resources/specs/service/PaymentService.html
+++ b/functionaltests/src/test/resources/specs/service/PaymentService.html
@@ -128,13 +128,12 @@
         <i>Status Text</i>, <i>Add Interface Interaction</i>, <i>Amount Paid</i>
     </h3>
     <table c:execute="#updatedPayment = updatePayment(#paymentName, #statusCode, #statusText, #sequenceNumber, #txAction,
-                                                        #notificationText, #paidCentAmount, #currencyCode)">
+                                                        #notificationText)">
         <tr>
             <th></th>
             <th>setStatusInterfaceCode</th>
             <th>setStatusInterfaceText</th>
             <th colspan="3">addInterfaceInteraction</th>
-            <th colspan="2">setAmountPaid</th>
             <th></th>
         </tr>
         <tr>
@@ -144,8 +143,6 @@
             <th c:set="#sequenceNumber">New Sequence Number</th>
             <th c:set="#txAction">New txAction</th>
             <th c:set="#notificationText">New Notification</th>
-            <th c:set="#paidCentAmount">New amount</th>
-            <th c:set="#currencyCode">New currency</th>
             <th c:assertEquals="#updatedPayment.version">Version</th>
         </tr>
         <tr>
@@ -155,8 +152,6 @@
             <td>11</td>
             <td>txAction_1</td>
             <td>NotificationText_1</td>
-            <td>1122</td>
-            <td>EUR</td>
             <td>5</td>
         </tr>
         <tr>
@@ -166,8 +161,6 @@
             <td>22</td>
             <td>txAction_2</td>
             <td>NotificationText_2</td>
-            <td>3344</td>
-            <td>USD</td>
             <td>5</td>
         </tr>
         <tr>
@@ -177,8 +170,6 @@
             <td>33</td>
             <td>txAction_3</td>
             <td>NotificationText_3</td>
-            <td>5566</td>
-            <td>UAH</td>
             <td>5</td>
         </tr>
         <tr>
@@ -188,8 +179,6 @@
             <td>44</td>
             <td>txAction_4</td>
             <td>NotificationText_4</td>
-            <td>7788</td>
-            <td>CAD</td>
             <td>5</td>
         </tr>
     </table>
@@ -201,7 +190,6 @@
             <th>setStatusInterfaceCode</th>
             <th>setStatusInterfaceText</th>
             <th colspan="3">addInterfaceInteraction</th>
-            <th>setAmountPaid</th>
             <th></th>
         </tr>
         <tr>
@@ -212,7 +200,6 @@
             <th c:assertEquals="#updatedPayment.sequenceNumber">Updated Sequence Number</th>
             <th c:assertEquals="#updatedPayment.txAction">Updated txAction</th>
             <th c:assertEquals="#updatedPayment.notificationText">Updated Notification</th>
-            <th c:assertEquals="#updatedPayment.paid">Updated paid amount</th>
         </tr>
         <tr>
             <td>Payment 1</td>
@@ -222,7 +209,6 @@
             <td>11</td>
             <td>txAction_1</td>
             <td>NotificationText_1</td>
-            <td>11,22 EUR</td>
         </tr>
         <tr>
             <td>Payment 2</td>
@@ -232,7 +218,6 @@
             <td>22</td>
             <td>txAction_2</td>
             <td>NotificationText_2</td>
-            <td>33,44 USD</td>
         </tr>
         <tr>
             <td>Payment 3</td>
@@ -242,7 +227,6 @@
             <td>33</td>
             <td>txAction_3</td>
             <td>NotificationText_3</td>
-            <td>55,66 UAH</td>
         </tr>
         <tr>
             <td>Payment 4</td>
@@ -252,7 +236,6 @@
             <td>44</td>
             <td>txAction_4</td>
             <td>NotificationText_4</td>
-            <td>77,88 CAD</td>
         </tr>
     </table>
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferWithoutIbanBicRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferWithoutIbanBicRequestFactory.java
@@ -6,10 +6,8 @@ import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingTy
 import com.commercetools.pspadapter.tenant.TenantConfig;
 import com.google.common.base.Preconditions;
 import io.sphere.sdk.payments.Payment;
-import org.javamoney.moneta.function.MonetaryUtil;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
 
 /**
  * Created by mht on 15.08.16.

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
@@ -8,10 +8,11 @@ import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.
 import com.commercetools.pspadapter.tenant.TenantConfig;
 import com.google.common.base.Preconditions;
 import io.sphere.sdk.payments.Payment;
-import org.javamoney.moneta.function.MonetaryUtil;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
+
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 
 /**
  *
@@ -48,11 +49,10 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
         request.setTxid(ctPayment.getInterfaceId());
 
         request.setSequencenumber(sequenceNumber);
-        Optional.ofNullable(ctPayment.getAmountPaid())
+        Optional.ofNullable(ctPayment.getAmountPlanned())
                 .ifPresent(amount -> {
                     request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(MonetaryUtil
-                            .minorUnits()
+                    request.setAmount(extractMinorPart()
                             .queryFrom(amount)
                             .intValue());
                 });

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
@@ -12,12 +12,10 @@ import io.sphere.sdk.payments.Payment;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
 /**
- *
  * @author mht@dotsource.de
- *
  */
 public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
 
@@ -52,7 +50,7 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
         Optional.ofNullable(ctPayment.getAmountPlanned())
                 .ifPresent(amount -> {
                     request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(extractMinorPart()
+                    request.setAmount(convertMinorPart()
                             .queryFrom(amount)
                             .intValue());
                 });

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactory.java
@@ -7,10 +7,11 @@ import com.commercetools.pspadapter.payone.domain.payone.model.creditcard.Credit
 import com.commercetools.pspadapter.tenant.TenantConfig;
 import com.google.common.base.Preconditions;
 import io.sphere.sdk.payments.Payment;
-import org.javamoney.moneta.function.MonetaryUtil;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
+
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 
 /**
  * @author fhaertig
@@ -63,11 +64,10 @@ public class CreditCardRequestFactory extends PayoneRequestFactory {
         request.setTxid(ctPayment.getInterfaceId());
 
         request.setSequencenumber(sequenceNumber);
-        Optional.ofNullable(ctPayment.getAmountAuthorized())
+        Optional.ofNullable(ctPayment.getAmountPlanned())
                 .ifPresent(amount -> {
                     request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(MonetaryUtil
-                            .minorUnits()
+                    request.setAmount(extractMinorPart()
                             .queryFrom(amount)
                             .intValue());
                 });

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactory.java
@@ -11,7 +11,7 @@ import io.sphere.sdk.payments.Payment;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
 /**
  * @author fhaertig
@@ -67,7 +67,7 @@ public class CreditCardRequestFactory extends PayoneRequestFactory {
         Optional.ofNullable(ctPayment.getAmountPlanned())
                 .ifPresent(amount -> {
                     request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(extractMinorPart()
+                    request.setAmount(convertMinorPart()
                             .queryFrom(amount)
                             .intValue());
                 });

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
@@ -28,7 +28,7 @@ import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUA
 import static com.commercetools.util.ServiceConstants.DEFAULT_LOCALE;
 import static java.util.Arrays.asList;
 import static java.util.Optional.ofNullable;
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
 /**
  * @author fhaertig
@@ -44,16 +44,16 @@ public class MappingUtil {
     public static final DateTimeFormatter yyyyMMdd = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private static final Set<CountryCode> countriesWithStateAllowed = ImmutableSet.of(
-        CountryCode.US,
-        CountryCode.CA,
-        CountryCode.CN,
-        CountryCode.JP,
-        CountryCode.MX,
-        CountryCode.BR,
-        CountryCode.AR,
-        CountryCode.ID,
-        CountryCode.TH,
-        CountryCode.IN
+            CountryCode.US,
+            CountryCode.CA,
+            CountryCode.CN,
+            CountryCode.JP,
+            CountryCode.MX,
+            CountryCode.BR,
+            CountryCode.AR,
+            CountryCode.ID,
+            CountryCode.TH,
+            CountryCode.IN
     );
 
     public static void mapBillingAddressToRequest(
@@ -155,7 +155,7 @@ public class MappingUtil {
         ofNullable(payment.getAmountPlanned())
                 .ifPresent(amount -> {
                     request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(extractMinorPart()
+                    request.setAmount(convertMinorPart()
                             .queryFrom(amount)
                             .intValue());
                 });

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
@@ -13,7 +13,6 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.types.CustomFields;
 import org.apache.commons.lang3.StringUtils;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +28,7 @@ import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUA
 import static com.commercetools.util.ServiceConstants.DEFAULT_LOCALE;
 import static java.util.Arrays.asList;
 import static java.util.Optional.ofNullable;
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 
 /**
  * @author fhaertig
@@ -155,8 +155,7 @@ public class MappingUtil {
         ofNullable(payment.getAmountPlanned())
                 .ifPresent(amount -> {
                     request.setCurrency(amount.getCurrency().getCurrencyCode());
-                    request.setAmount(MonetaryUtil
-                            .minorUnits()
+                    request.setAmount(extractMinorPart()
                             .queryFrom(amount)
                             .intValue());
                 });

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/DefaultChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/DefaultChargeTransactionExecutor.java
@@ -136,7 +136,6 @@ public class DefaultChargeTransactionExecutor extends TransactionBaseExecutor {
                             setStatusInterfaceCode(response),
                             setStatusInterfaceText(response),
                             SetInterfaceId.of(response.get("txid")),
-                            SetAuthorization.of(updatedPayment.getAmountPlanned()),
                             ChangeTransactionState.of(TransactionState.SUCCESS, transaction.getId()),
                             ChangeTransactionTimestamp.of(ZonedDateTime.now(), transaction.getId())
                     ));

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/creditcard/AuthorizationTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/creditcard/AuthorizationTransactionExecutor.java
@@ -129,8 +129,7 @@ public class AuthorizationTransactionExecutor extends TransactionBaseExecutor {
                             setStatusInterfaceText(response),
                             ChangeTransactionState.of(TransactionState.SUCCESS, transaction.getId()),
                             ChangeTransactionTimestamp.of(ZonedDateTime.now(), transaction.getId()),
-                            SetInterfaceId.of(response.get("txid")),
-                            SetAuthorization.of(paymentWithCartLike.getPayment().getAmountPlanned())
+                            SetInterfaceId.of(response.get("txid"))
                     ));
                 } else if (ResponseStatus.ERROR.getStateCode().equals(status)) {
                     return update(paymentWithCartLike, updatedPayment, ImmutableList.of(

--- a/service/src/main/java/com/commercetools/pspadapter/payone/util/MoneyUtil.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/util/MoneyUtil.java
@@ -72,7 +72,7 @@ public final class MoneyUtil {
     }
 
     public static Optional<MonetaryAmount> getTotalDiscountedPriceMonetaryPerQuantity(@Nonnull LineItemLike lineItemLike) {
-        return Optional.of(lineItemLike.getDiscountedPricePerQuantity())
+        return Optional.ofNullable(lineItemLike.getDiscountedPricePerQuantity())
                 .filter(dppq -> dppq.size() > 0)
                 .flatMap(dppq -> dppq.stream()
                         .map(dlipfq -> dlipfq.getDiscountedPrice().getValue().multiply(dlipfq.getQuantity()))

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
@@ -10,7 +10,6 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,6 +19,7 @@ import util.PaymentTestHelper;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +83,7 @@ public class BankTransferInAdvanceRequestFactoryTest extends BaseTenantPropertyT
         softly.assertThat(result.getCustomerid()).isEqualTo(payment.getCustomer().getObj().getCustomerNumber());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
@@ -19,13 +19,12 @@ import util.PaymentTestHelper;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 /**
  * @author mht@dotsource.de
- *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class BankTransferInAdvanceRequestFactoryTest extends BaseTenantPropertyTest {
@@ -83,7 +82,7 @@ public class BankTransferInAdvanceRequestFactoryTest extends BaseTenantPropertyT
         softly.assertThat(result.getCustomerid()).isEqualTo(payment.getCustomer().getObj().getCustomerNumber());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUAGE_CODE_FIELD;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
 /**
  * @author fhaertig
@@ -77,7 +77,7 @@ public class CreditCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -211,7 +211,7 @@ public class CreditCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getIntegratorVersion()).isEqualTo(payoneConfig.getIntegratorVersion());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         softly.assertThat(result.getTxid()).isEqualTo(payment.getInterfaceId());

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
@@ -191,7 +191,6 @@ public class CreditCardRequestFactoryTest extends BaseTenantPropertyTest {
 
     @Test
     public void createFullCaptureRequestFromValidPayment() throws Exception {
-
         Payment payment = payments.dummyPaymentOneChargePending20Euro();
         Order order = payments.dummyOrderMapToPayoneRequest();
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
@@ -212,8 +211,8 @@ public class CreditCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getIntegratorVersion()).isEqualTo(payoneConfig.getIntegratorVersion());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountAuthorized()).intValue());
-        softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountAuthorized().getCurrency().getCurrencyCode());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         softly.assertThat(result.getTxid()).isEqualTo(payment.getInterfaceId());
         softly.assertThat(result.getSequencenumber()).isEqualTo(Integer.valueOf(payment.getTransactions().get(0).getInteractionId()));

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactoryTest.java
@@ -13,7 +13,6 @@ import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +24,7 @@ import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUAGE_CODE_FIELD;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 
 /**
  * @author fhaertig
@@ -77,7 +77,7 @@ public class CreditCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -212,7 +212,7 @@ public class CreditCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getIntegratorVersion()).isEqualTo(payoneConfig.getIntegratorVersion());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountAuthorized()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountAuthorized()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountAuthorized().getCurrency().getCurrencyCode());
 
         softly.assertThat(result.getTxid()).isEqualTo(payment.getInterfaceId());

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactoryTest.java
@@ -12,7 +12,6 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +22,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUAGE_CODE_FIELD;
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 
 /**
  * @author fhaertig
@@ -78,7 +78,7 @@ public class PaypalRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -155,7 +155,7 @@ public class PaypalRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactoryTest.java
@@ -22,7 +22,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUAGE_CODE_FIELD;
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
 /**
  * @author fhaertig
@@ -42,7 +42,7 @@ public class PaypalRequestFactoryTest extends BaseTenantPropertyTest {
     }
 
     @Test
-     public void createFullPreauthorizationRequestFromValidPayment() throws Exception {
+    public void createFullPreauthorizationRequestFromValidPayment() throws Exception {
 
         Payment payment = payments.dummyPaymentOneAuthPending20EuroPPE();
         Order order = payments.dummyOrderMapToPayoneRequest();
@@ -78,7 +78,7 @@ public class PaypalRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -155,7 +155,7 @@ public class PaypalRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
@@ -10,7 +10,6 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +20,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUAGE_CODE_FIELD;
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +83,7 @@ public class PostfinanceCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
@@ -20,13 +20,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.LANGUAGE_CODE_FIELD;
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 /**
  * @author mht@dotsource.de
- *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PostfinanceCardRequestFactoryTest extends BaseTenantPropertyTest {
@@ -83,7 +82,7 @@ public class PostfinanceCardRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(payment.getCustom().getFieldAsString(LANGUAGE_CODE_FIELD));
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
@@ -19,7 +19,7 @@ import util.PaymentTestHelper;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +79,7 @@ public class PostfinanceEfinanceRequestFactoryTest extends BaseTenantPropertyTes
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
@@ -10,7 +10,6 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,12 +19,12 @@ import util.PaymentTestHelper;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 /**
  * @author mht@dotsource.de
- *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PostfinanceEfinanceRequestFactoryTest extends BaseTenantPropertyTest {
@@ -80,7 +79,7 @@ public class PostfinanceEfinanceRequestFactoryTest extends BaseTenantPropertyTes
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
@@ -22,7 +22,7 @@ import util.PaymentTestHelper;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -88,7 +88,7 @@ public class SofortRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -175,7 +175,7 @@ public class SofortRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getCustomerid()).isEqualTo(payment.getCustomer().getObj().getCustomerNumber());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
@@ -13,7 +13,6 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +22,7 @@ import util.PaymentTestHelper;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -88,7 +88,7 @@ public class SofortRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -175,7 +175,7 @@ public class SofortRequestFactoryTest extends BaseTenantPropertyTest {
         softly.assertThat(result.getCustomerid()).isEqualTo(payment.getCustomer().getObj().getCustomerNumber());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
@@ -13,16 +13,15 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.assertj.core.api.SoftAssertions;
-import org.javamoney.moneta.function.MonetaryUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import util.PaymentTestHelper;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +89,7 @@ public class SofortWithoutIbanRequestFactoryTest extends BaseTenantPropertyTest 
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -177,7 +176,7 @@ public class SofortWithoutIbanRequestFactoryTest extends BaseTenantPropertyTest 
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(MonetaryUtil.minorUnits().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
@@ -21,7 +21,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
-import static org.javamoney.moneta.function.MonetaryQueries.extractMinorPart;
+import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -89,7 +89,7 @@ public class SofortWithoutIbanRequestFactoryTest extends BaseTenantPropertyTest 
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls
@@ -176,7 +176,7 @@ public class SofortWithoutIbanRequestFactoryTest extends BaseTenantPropertyTest 
         softly.assertThat(result.getLanguage()).isEqualTo(order.getLocale().getLanguage());
 
         //monetary
-        softly.assertThat(result.getAmount()).isEqualTo(extractMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
+        softly.assertThat(result.getAmount()).isEqualTo(convertMinorPart().queryFrom(payment.getAmountPlanned()).intValue());
         softly.assertThat(result.getCurrency()).isEqualTo(payment.getAmountPlanned().getCurrency().getCurrencyCode());
 
         //urls

--- a/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/AppointedNotificationProcessorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/AppointedNotificationProcessorTest.java
@@ -129,20 +129,8 @@ public class AppointedNotificationProcessorTest extends BaseNotificationProcesso
         final SetStatusInterfaceCode statusInterfaceCode = getSetStatusInterfaceCode(notification);
         final SetStatusInterfaceText statusInterfaceText = getSetStatusInterfaceText(notification);
 
-        assertThat(updateActions)
-                .filteredOn(u -> u.getAction().equals("setAuthorization"))
-                .containsOnly(SetAuthorization.of(payment.getAmountPlanned()));
-        assertThat(updateActions)
-                .filteredOn(u -> u.getAction().equals("addTransaction"))
-                .usingElementComparatorOnFields(
-                        "transaction.type",
-                        "transaction.amount",
-                        "transaction.state",
-                        "transaction.timestamp",
-                        "transaction.interactionId")
-                .containsOnlyOnce(transaction);
-        assertStandardUpdateActions(updateActions, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
-        assertThat(updateActions).as("# of update actions").hasSize(5);
+        assertThat(updateActions).as("update actions list")
+                .containsExactlyInAnyOrder(transaction, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
 
         verifyUpdateOrderActions(payment, ORDER_PAYMENT_STATE);
     }
@@ -412,19 +400,10 @@ public class AppointedNotificationProcessorTest extends BaseNotificationProcesso
         final SetStatusInterfaceCode statusInterfaceCode = getSetStatusInterfaceCode(notification);
         final SetStatusInterfaceText statusInterfaceText = getSetStatusInterfaceText(notification);
 
-        assertThat(updateActions).as("setAuthorization action")
-                .filteredOn(u -> u.getAction().equals("setAuthorization"))
-                .containsOnly(SetAuthorization.of(payment.getAmountPlanned()));
-
-        assertThat(updateActions).as("changeTransactionState action")
-                .filteredOn(u -> u.getAction().equals("changeTransactionState"))
-                .containsOnly(
-                        ChangeTransactionState.of(TransactionState.SUCCESS, payment.getTransactions().get(0).getId()));
-
-
-        assertStandardUpdateActions(updateActions, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
-
-        assertThat(updateActions).as("# of update actions").hasSize(5);
+        assertThat(updateActions).as("update actions list")
+                .containsExactlyInAnyOrder(
+                        ChangeTransactionState.of(TransactionState.SUCCESS, payment.getTransactions().get(0).getId()),
+                        interfaceInteraction, statusInterfaceCode, statusInterfaceText);
 
         verifyUpdateOrderActions(payment, ORDER_PAYMENT_STATE);
     }

--- a/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/PaidNotificationProcessorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/PaidNotificationProcessorTest.java
@@ -81,21 +81,11 @@ public class PaidNotificationProcessorTest extends BaseChargedNotificationProces
                 .build());
 
         final AddInterfaceInteraction interfaceInteraction = getAddInterfaceInteraction(notification, timestamp);
-
-        assertThat(updateActions).as("# of payment update actions").hasSize(5);
-        assertThat(updateActions).as("added transaction")
-                .filteredOn(u -> u.getAction().equals("addTransaction"))
-                .usingElementComparatorOnFields(
-                        "transaction.type", "transaction.amount", "transaction.state", "transaction.timestamp")
-                .containsOnlyOnce(transaction);
-
-        assertThat(updateActions).as("amount paid")
-                .filteredOn(u -> u.getAction().equals("setAmountPaid"))
-                .containsOnly(SetAmountPaid.of(MoneyImpl.of(notification.getPrice(), notification.getCurrency())));
         final SetStatusInterfaceCode statusInterfaceCode = getSetStatusInterfaceCode(notification);
         final SetStatusInterfaceText statusInterfaceText = getSetStatusInterfaceText(notification);
 
-        assertStandardUpdateActions(updateActions, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
+        assertThat(updateActions).as("added transactions")
+                .containsExactlyInAnyOrder(transaction, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
 
         verifyUpdateOrderActions(payment, ORDER_PAYMENT_STATE);
     }
@@ -145,16 +135,11 @@ public class PaidNotificationProcessorTest extends BaseChargedNotificationProces
         final SetStatusInterfaceCode statusInterfaceCode = getSetStatusInterfaceCode(notification);
         final SetStatusInterfaceText statusInterfaceText = getSetStatusInterfaceText(notification);
 
-        assertThat(updateActions).as("# of payment update actions").hasSize(5);
-        assertThat(updateActions).as("transaction state change")
-                .filteredOn(u -> u.getAction().equals("changeTransactionState"))
-                .containsOnly(ChangeTransactionState.of(TransactionState.SUCCESS, chargeTransaction.getId()));
+        assertThat(updateActions).as("payment update actions list")
+                .containsExactlyInAnyOrder(
+                        ChangeTransactionState.of(TransactionState.SUCCESS, chargeTransaction.getId()),
+                        interfaceInteraction, statusInterfaceCode, statusInterfaceText);
 
-        assertThat(updateActions).as("amount paid")
-                .filteredOn(u -> u.getAction().equals("setAmountPaid"))
-                .containsOnly(SetAmountPaid.of(MoneyImpl.of(notification.getPrice(), notification.getCurrency())));
-
-        assertStandardUpdateActions(updateActions, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
         return payment;
     }
 

--- a/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
@@ -11,6 +11,7 @@ import com.commercetools.pspadapter.payone.mapping.CountryToLanguageMapper;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.google.common.cache.LoadingCache;
 import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.client.SphereClientConfig;
 import io.sphere.sdk.types.Type;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +45,8 @@ public class TenantFactoryTest {
         when(payoneConfig.getApiUrl()).thenReturn("http://test.api.url");
         when(tenantConfig.getPayoneConfig()).thenReturn(payoneConfig);
         when(tenantConfig.getName()).thenReturn("testTenantName");
+        when(tenantConfig.getSphereClientConfig())
+                .thenReturn(SphereClientConfig.of("test-key", "test-client-id", "test-client-secret"));
 
         factory = new TenantFactory("testPayoneInterfaceName", tenantConfig);
     }

--- a/service/src/test/resources/com/commercetools/pspadapter/payone/mapping/klarna/dummyKlarnaCart.json
+++ b/service/src/test/resources/com/commercetools/pspadapter/payone/mapping/klarna/dummyKlarnaCart.json
@@ -1,21 +1,17 @@
 {
   "type": "Cart",
-  "id": "0756a2bb-f1c6-4a96-bcbb-7624f12b9c1a",
-  "version": 12,
   "customerEmail": "youremail@email.com",
   "createdAt": "2017-05-29T08:16:08.351Z",
   "lastModifiedAt": "2017-05-29T08:16:08.988Z",
   "lineItems": [
     {
-      "id": "0c7b259b-25eb-456e-a85e-9a482fba901a",
-      "productId": "aa5bf70f-ee70-4587-a7e6-765eeefab252",
+      "productId":"55555555-5555-5555-5555-555555555555",
       "name": {
         "en": "Necklace",
         "de": "Halskette"
       },
       "productType": {
-        "typeId": "product-type",
-        "id": "9c632515-6d7a-4385-8438-671a822b1b82"
+        "typeId": "product-type"
       },
       "productSlug": {
         "en": "necklace-123454323454667"
@@ -28,15 +24,13 @@
             "value": {
               "currencyCode": "EUR",
               "centAmount": 12999
-            },
-            "id": "5c3bba8e-ffdf-4e33-9c6a-803e92bb34d7"
+            }
           },
           {
             "value": {
               "currencyCode": "CHF",
               "centAmount": 11998
-            },
-            "id": "320b1711-a3af-4840-b9c6-e64e3fcfc6b1"
+            }
           }
         ],
         "images": [],
@@ -47,8 +41,7 @@
         "value": {
           "currencyCode": "EUR",
           "centAmount": 12999
-        },
-        "id": "5c3bba8e-ffdf-4e33-9c6a-803e92bb34d7"
+        }
       },
       "quantity": 4,
       "discountedPrice": {
@@ -59,8 +52,7 @@
         "includedDiscounts": [
           {
             "discount": {
-              "typeId": "cart-discount",
-              "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+              "typeId": "cart-discount"
             },
             "discountedAmount": {
               "currencyCode": "EUR",
@@ -69,8 +61,7 @@
           },
           {
             "discount": {
-              "typeId": "cart-discount",
-              "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+              "typeId": "cart-discount"
             },
             "discountedAmount": {
               "currencyCode": "EUR",
@@ -90,8 +81,7 @@
             "includedDiscounts": [
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -100,8 +90,7 @@
               },
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -121,8 +110,7 @@
             "includedDiscounts": [
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -131,8 +119,7 @@
               },
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -155,8 +142,7 @@
         {
           "quantity": 4,
           "state": {
-            "typeId": "state",
-            "id": "9ae7b755-6d83-4316-8c5c-87ec1ef88716"
+            "typeId": "state"
           }
         }
       ],
@@ -177,15 +163,13 @@
       }
     },
     {
-      "id": "ea1a6c0f-260a-4040-b00c-e15375e833ce",
-      "productId": "fbe5f5a7-3ce5-4290-b094-9b79391d01f2",
+      "productId":"66666666-6666-6666-6666-666666666666",
       "name": {
         "en": "box",
         "de": "Kasten"
       },
       "productType": {
-        "typeId": "product-type",
-        "id": "9c632515-6d7a-4385-8438-671a822b1b82"
+        "typeId": "product-type"
       },
       "productSlug": {
         "en": "box-2345234523"
@@ -198,8 +182,7 @@
             "value": {
               "currencyCode": "EUR",
               "centAmount": 0
-            },
-            "id": "cc9ffb9f-1433-4707-aaca-74d3365139af"
+            }
           }
         ],
         "images": [],
@@ -210,8 +193,7 @@
         "value": {
           "currencyCode": "EUR",
           "centAmount": 0
-        },
-        "id": "cc9ffb9f-1433-4707-aaca-74d3365139af"
+        }
       },
       "quantity": 1,
       "discountedPrice": {
@@ -222,8 +204,7 @@
         "includedDiscounts": [
           {
             "discount": {
-              "typeId": "cart-discount",
-              "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+              "typeId": "cart-discount"
             },
             "discountedAmount": {
               "currencyCode": "EUR",
@@ -232,8 +213,7 @@
           },
           {
             "discount": {
-              "typeId": "cart-discount",
-              "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+              "typeId": "cart-discount"
             },
             "discountedAmount": {
               "currencyCode": "EUR",
@@ -253,8 +233,7 @@
             "includedDiscounts": [
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -263,8 +242,7 @@
               },
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -287,8 +265,7 @@
         {
           "quantity": 1,
           "state": {
-            "typeId": "state",
-            "id": "9ae7b755-6d83-4316-8c5c-87ec1ef88716"
+            "typeId": "state"
           }
         }
       ],
@@ -309,15 +286,13 @@
       }
     },
     {
-      "id": "7bd2b824-218f-45c2-85ac-be30455d379d",
-      "productId": "64b7b5b6-1926-44c9-87ee-46d2f17c1538",
+      "productId":"77777777-7777-7777-7777-777777777777",
       "name": {
         "en": "Ring",
         "de": "Ringe"
       },
       "productType": {
-        "typeId": "product-type",
-        "id": "9c632515-6d7a-4385-8438-671a822b1b82"
+        "typeId": "product-type"
       },
       "productSlug": {
         "en": "ring-456786468866578"
@@ -330,15 +305,13 @@
             "value": {
               "currencyCode": "EUR",
               "centAmount": 4923
-            },
-            "id": "8ee4277f-91f2-4ee7-b5bc-fa1988b56e14"
+            }
           },
           {
             "value": {
               "currencyCode": "CHF",
               "centAmount": 4511
-            },
-            "id": "98590d9c-3716-4b5c-a75d-c9dc339660a0"
+            }
           }
         ],
         "images": [],
@@ -349,8 +322,7 @@
         "value": {
           "currencyCode": "EUR",
           "centAmount": 4923
-        },
-        "id": "8ee4277f-91f2-4ee7-b5bc-fa1988b56e14"
+        }
       },
       "quantity": 3,
       "discountedPrice": {
@@ -361,8 +333,7 @@
         "includedDiscounts": [
           {
             "discount": {
-              "typeId": "cart-discount",
-              "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+              "typeId": "cart-discount"
             },
             "discountedAmount": {
               "currencyCode": "EUR",
@@ -371,8 +342,7 @@
           },
           {
             "discount": {
-              "typeId": "cart-discount",
-              "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+              "typeId": "cart-discount"
             },
             "discountedAmount": {
               "currencyCode": "EUR",
@@ -392,8 +362,7 @@
             "includedDiscounts": [
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -402,8 +371,7 @@
               },
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -423,8 +391,7 @@
             "includedDiscounts": [
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "59ae8cb2-26e4-411e-96b5-a13265d334e2"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -433,8 +400,7 @@
               },
               {
                 "discount": {
-                  "typeId": "cart-discount",
-                  "id": "f710cf37-4817-40ed-ae1a-8dc09bf2c397"
+                  "typeId": "cart-discount"
                 },
                 "discountedAmount": {
                   "currencyCode": "EUR",
@@ -457,8 +423,7 @@
         {
           "quantity": 3,
           "state": {
-            "typeId": "state",
-            "id": "9ae7b755-6d83-4316-8c5c-87ec1ef88716"
+            "typeId": "state"
           }
         }
       ],
@@ -533,15 +498,13 @@
   "discountCodes": [
     {
       "discountCode": {
-        "typeId": "discount-code",
-        "id": "fdcbc045-b7c2-4dae-9471-31d6b7f04c5d"
+        "typeId": "discount-code"
       },
       "state": "MatchesCart"
     },
     {
       "discountCode": {
-        "typeId": "discount-code",
-        "id": "076aff82-e711-44a4-9e6e-c9270e953a65"
+        "typeId": "discount-code"
       },
       "state": "MatchesCart"
     }
@@ -567,13 +530,11 @@
       "subRates": []
     },
     "taxCategory": {
-      "typeId": "tax-category",
-      "id": "ce0fd21f-530e-4ae4-b5ac-d3e601b4b715"
+      "typeId": "tax-category"
     },
     "deliveries": [],
     "shippingMethod": {
-      "typeId": "shipping-method",
-      "id": "c6de349f-edcd-444f-a33f-3b50be7fd34d"
+      "typeId": "shipping-method"
     },
     "taxedPrice": {
       "totalNet": {

--- a/service/src/test/resources/com/commercetools/pspadapter/payone/mapping/klarna/dummyKlarnaCartWithoutDiscounts.json
+++ b/service/src/test/resources/com/commercetools/pspadapter/payone/mapping/klarna/dummyKlarnaCartWithoutDiscounts.json
@@ -5,6 +5,7 @@
   "lastModifiedAt": "2017-05-23T15:49:09.238Z",
   "lineItems": [
     {
+      "productId":"33333333-3333-3333-3333-333333333333",
       "name": {
         "de": "Collier Swarovski",
         "en": "Necklace Swarovski"
@@ -71,6 +72,7 @@
       }
     },
     {
+      "productId":"44444444-4444-4444-4444-444444444444",
       "name": {
         "de": "Jedes Schmuckstück",
         "en": "Every piece"
@@ -135,6 +137,7 @@
       }
     },
     {
+      "productId":"88888888-8888-8888-8888-888888888888",
       "name": {
         "en": "Earrings",
         "de": "Ohrringe"

--- a/service/src/test/resources/com/commercetools/pspadapter/payone/util/dummyLineItemWithDiscount.json
+++ b/service/src/test/resources/com/commercetools/pspadapter/payone/util/dummyLineItemWithDiscount.json
@@ -1,4 +1,5 @@
 {
+  "productId":"11111111-1111-1111-1111-111111111111",
   "name": {
     "de": "Armband blau",
     "en": "Bracelet blue"

--- a/service/src/test/resources/com/commercetools/pspadapter/payone/util/dummyLineItemWithoutDiscount.json
+++ b/service/src/test/resources/com/commercetools/pspadapter/payone/util/dummyLineItemWithoutDiscount.json
@@ -1,4 +1,5 @@
 {
+  "productId":"22222222-2222-2222-2222-222222222222",
   "name": {
     "de": "Armband blau",
     "en": "Bracelet blue"
@@ -43,6 +44,7 @@
     "country": "GB"
   },
   "quantity": 3,
+  "discountedPricePerQuantity": [],
   "taxRate": {
     "name": "UK",
     "amount": 0.19,

--- a/service/src/test/resources/dummyPaymentAuthSuccess.json
+++ b/service/src/test/resources/dummyPaymentAuthSuccess.json
@@ -5,10 +5,6 @@
     "currencyCode": "EUR",
     "centAmount": 2000
   },
-  "amountAuthorized": {
-    "currencyCode": "EUR",
-    "centAmount": 2000
-  },
   "customer": {
     "typeId": "customer",
     "id": "276829bd-6fa3-450f-9e2a-9a8715a9a104",

--- a/service/src/test/resources/dummyPaymentOneChargePending20Euro.json
+++ b/service/src/test/resources/dummyPaymentOneChargePending20Euro.json
@@ -5,10 +5,6 @@
     "currencyCode": "EUR",
     "centAmount": 2000
   },
-  "amountAuthorized": {
-    "currencyCode": "EUR",
-    "centAmount": 2000
-  },
   "customer": {
     "typeId": "customer",
     "id": "276829bd-6fa3-450f-9e2a-9a8715a9a104",

--- a/service/src/test/resources/dummyPaymentTwoTransactionsSuccessPending.json
+++ b/service/src/test/resources/dummyPaymentTwoTransactionsSuccessPending.json
@@ -5,10 +5,6 @@
     "currencyCode": "EUR",
     "centAmount": 20000
   },
-  "amountPaid": {
-    "currencyCode": "EUR",
-    "centAmount": 20000
-  },
   "paymentMethodInfo": {
     "paymentInterface": "PAYONE",
     "method": "CREDIT_CARD"


### PR DESCRIPTION
In this PR all the project dependencies were strongly updated/re-factored to the most recent versions:
  - _service_:
    - `CT JVM SDK` `1.13.0` -> `1.25.0`
      - remove deprecated properties usage and tests (_amountAuthorized_, _amountPaid_, _ amountRefunded_)
      - explicitly specify _productId_ field on cart mocks since it is required by JVM SDK now.
    - `guava`, `unirest`, `logback`, `spark`, `quartz`
    - test dependencies: `hamcrest`, `assertJ`, `mockito` (see also #182)
    - removed out of date `moneta`, `nv-i18n`
      - use `MonetaryQueries` instead of deprecated `MonetaryUtil`
      - `fluent-hc` will be removed in #185 
  - _functionaltests_:
    - `selenium 3.6.0`
  - use the newest gradle _implementation_ dependency including instead of deprecated _compile_
  - re-factor dependencies including location (e.g. remove test dependencies from compile scope, remove _functionaltest_ dependencies form _service_ project)



