### PR TITLE
176 health response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,10 @@ project(":service") {
     }
 
     shadowJar {
-        archiveName = "commercetools-payone-integration.jar"
+        baseName = rootProject.name
+        classifier = null
+        version = null
+
         manifest {
             attributes 'Main-Class': project.mainClassName
 

--- a/functionaltests/src/test/java/specs/response/HealthResponseFixture.java
+++ b/functionaltests/src/test/java/specs/response/HealthResponseFixture.java
@@ -1,13 +1,21 @@
 package specs.response;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.concordion.api.MultiValueResult;
 import org.concordion.integration.junit4.ConcordionRunner;
-import org.json.JSONObject;
 import org.junit.runner.RunWith;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.joining;
 
 /**
  * Simple /health URL response checker
@@ -27,10 +35,40 @@ public class HealthResponseFixture extends BasePaymentFixture {
 
         String responseString = new BasicResponseHandler().handleResponse(httpResponse);
 
+        ObjectMapper mapper = new ObjectMapper();
+        final JsonNode jsonNode = mapper.readTree(responseString);
+        final Optional<JsonNode> tenantNames = ofNullable(jsonNode.get("tenants")).filter(JsonNode::isArray);
+        Optional<JsonNode> applicationInfo = ofNullable(jsonNode.get("applicationInfo")).filter(JsonNode::isObject);
+        String title = applicationInfo.map(node -> node.get("title")).map(JsonNode::textValue).orElse("");
+        String version = applicationInfo.map(node -> node.get("version")).map(JsonNode::textValue).orElse("");
+
         return MultiValueResult.multiValueResult()
                 .with("statusCode", httpResponse.getStatusLine().getStatusCode())
                 .with("mimeType", ContentType.getOrDefault(httpResponse.getEntity()).getMimeType())
-                .with("bodyStatus", (new JSONObject(responseString)).getInt("status"));
+                .with("bodyStatus", jsonNode.get("status"))
+                .with("bodyTenants", tenantNames.map(JsonNode::toString).orElse("undefined"))
+                .with("bodyTenantsSize", tenantNames.map(JsonNode::size).orElse(0))
+                .with("bodyApplicationName", title)
+                .with("bodyApplicationVersion", version)
+                .with("versionIsEmpty", version.isEmpty());
+    }
+
+    /**
+     * Join with "+" tenant names in alphabetical order
+     * @param jsonObject
+     * @return
+     */
+    private static String concatTenantNames(final JsonNode jsonObject) {
+        return ofNullable(jsonObject)
+                .filter(JsonNode::isArray)
+                .map(arr -> IntStream.range(0, arr.size())
+                        .mapToObj(arr::get)
+                        .filter(Objects::nonNull)
+                        .map(JsonNode::textValue)
+                        .sorted()
+                        .collect(joining("+")))
+                .orElse("");
+
     }
 
 }

--- a/functionaltests/src/test/java/specs/response/HealthResponseFixture.java
+++ b/functionaltests/src/test/java/specs/response/HealthResponseFixture.java
@@ -28,7 +28,7 @@ public class HealthResponseFixture extends BasePaymentFixture {
     }
 
     public MultiValueResult handleHealthResponse() throws Exception {
-        final HttpResponse httpResponse = Request.Get(getHealthUrl())
+        HttpResponse httpResponse = Request.Get(getHealthUrl())
                 .connectTimeout(SIMPLE_REQUEST_TIMEOUT)
                 .execute()
                 .returnResponse();
@@ -36,8 +36,8 @@ public class HealthResponseFixture extends BasePaymentFixture {
         String responseString = new BasicResponseHandler().handleResponse(httpResponse);
 
         ObjectMapper mapper = new ObjectMapper();
-        final JsonNode jsonNode = mapper.readTree(responseString);
-        final Optional<JsonNode> tenantNames = ofNullable(jsonNode.get("tenants")).filter(JsonNode::isArray);
+        JsonNode jsonNode = mapper.readTree(responseString);
+        Optional<JsonNode> tenantNames = ofNullable(jsonNode.get("tenants")).filter(JsonNode::isArray);
         Optional<JsonNode> applicationInfo = ofNullable(jsonNode.get("applicationInfo")).filter(JsonNode::isObject);
         String title = applicationInfo.map(node -> node.get("title")).map(JsonNode::textValue).orElse("");
         String version = applicationInfo.map(node -> node.get("version")).map(JsonNode::textValue).orElse("");

--- a/functionaltests/src/test/resources/specs/response/HealthResponse.html
+++ b/functionaltests/src/test/resources/specs/response/HealthResponse.html
@@ -15,11 +15,21 @@ Test we get correct response status, mime-type and message from
             <th c:assertEquals="#result.statusCode">Status Code</th>
             <th c:assertEquals="#result.mimeType">Mime Type</th>
             <th c:assertEquals="#result.bodyStatus">Body status({&quot;status&quot;:200})</th>
+            <th c:echo="#result.bodyTenants">Tenants (info)</th>
+            <th c:assertEquals="#result.bodyTenantsSize">Tenants list size</th>
+            <th c:assertEquals="#result.bodyApplicationName">Application title</th>
+            <th c:assertEquals="#result.versionIsEmpty">Is version empty?</th>
+            <th c:echo="#result.bodyApplicationVersion">Version (info)</th>
         </tr>
         <tr>
             <td>200</td>
             <td>application/json</td>
             <td>200</td>
+            <td></td>
+            <td>2</td>
+            <td>commercetools-payone-integration</td>
+            <td>false</td>
+            <td></td>
         </tr>
     </table>
 </div>

--- a/service/src/main/java/com/commercetools/Main.java
+++ b/service/src/main/java/com/commercetools/Main.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 
-import static com.commercetools.pspadapter.payone.config.PropertyProvider.PAYONE_INTEGRATOR_VERSION;
 import static java.lang.String.format;
 
 public class Main {
@@ -28,9 +27,16 @@ public class Main {
         ScheduledJobFactory scheduledJobFactory = new ScheduledJobFactory();
 
         scheduledJobFactory.setAllScheduledItemsStartedListener(() ->
-                LOG.info(format("%n%1$s%nPayone Integration Service is STARTED%nVersion: %2$s%n%1$s",
+                LOG.info(format("%n%s %n" +
+                                "Payone Integration Service is STARTED %n" +
+                                "%-10s %s %n" +
+                                "%-10s %s %n" +
+                                "%s",
                         "============================================================",
-                        propertyProvider.getProperty(PAYONE_INTEGRATOR_VERSION).orElse("DEBUG-VERSION")))
+                        "Name:", serviceConfig.getApplicationName(),
+                        "Version:", serviceConfig.getApplicationVersion(),
+                        "============================================================"
+                ))
         );
 
         scheduledJobFactory.createScheduledJob(

--- a/service/src/main/java/com/commercetools/pspadapter/payone/ServiceFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/ServiceFactory.java
@@ -1,27 +1,12 @@
 package com.commercetools.pspadapter.payone;
 
-import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
 import com.commercetools.pspadapter.payone.config.ServiceConfig;
-import com.commercetools.pspadapter.tenant.TenantConfig;
-import com.commercetools.pspadapter.tenant.TenantFactory;
-import com.commercetools.pspadapter.tenant.TenantPropertyProvider;
-
-import java.util.List;
-
-import static com.commercetools.pspadapter.payone.util.PayoneConstants.PAYONE;
-import static java.util.stream.Collectors.toList;
 
 public class ServiceFactory {
 
     public static IntegrationService createIntegrationService(PropertyProvider propertyProvider, ServiceConfig serviceConfig) {
-        List<TenantFactory> tenantFactories = serviceConfig.getTenants().stream()
-                .map(tenantName -> new TenantPropertyProvider(tenantName, propertyProvider))
-                .map(tenantPropertyProvider -> new TenantConfig(tenantPropertyProvider, new PayoneConfig(tenantPropertyProvider)))
-                .map(tenantConfig -> new TenantFactory(PAYONE, tenantConfig))
-                .collect(toList());
-
-        return new IntegrationService(tenantFactories);
+        return new IntegrationService(serviceConfig, propertyProvider);
     }
 
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
+import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * @author fhaertig
@@ -36,13 +38,14 @@ public class PropertyProvider {
     private final List<Function<String, String>> propertiesGetters;
 
     public PropertyProvider() {
+        String implementationTitle = ofNullable(getClass().getPackage().getImplementationTitle()).orElse("DEBUG-TITLE");
         String implementationVersion = ofNullable(getClass().getPackage().getImplementationVersion()).orElse("DEBUG-VERSION");
         internalProperties = ImmutableMap.<String, String>builder()
                 .put(PAYONE_API_VERSION, "3.9")
                 .put(PAYONE_REQUEST_ENCODING, "UTF-8")
                 .put(PAYONE_SOLUTION_NAME, "commercetools-platform")
                 .put(PAYONE_SOLUTION_VERSION, "1")
-                .put(PAYONE_INTEGRATOR_NAME, "commercetools-payone-integration")
+                .put(PAYONE_INTEGRATOR_NAME, implementationTitle)
                 .put(PAYONE_INTEGRATOR_VERSION, implementationVersion)
                 .build();
 
@@ -58,16 +61,18 @@ public class PropertyProvider {
      *     <li>fetch from hardcoded {@link #internalProperties} map.</li>
      * </ul>
      * <p>
-     *     If neither of them exists - empty {@link Optional} is returned.
+     * If neither of them exists - empty {@link Optional} is returned.
      *
      * @param propertyName the name of the requested property, must not be null
      * @return the property, an empty Optional if not present; empty values are treated as present
      */
     public Optional<String> getProperty(final String propertyName) {
-        return propertiesGetters.stream()
-                .map(getter -> getter.apply(propertyName))
-                .filter(Objects::nonNull)
-                .findFirst();
+        return isNotBlank(propertyName)
+                ? propertiesGetters.stream()
+                    .map(getter -> getter.apply(propertyName))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                : empty();
     }
 
     /**

--- a/service/src/main/java/com/commercetools/pspadapter/payone/config/ServiceConfig.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/config/ServiceConfig.java
@@ -2,8 +2,10 @@ package com.commercetools.pspadapter.payone.config;
 
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
+import static com.commercetools.pspadapter.payone.config.PropertyProvider.*;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -21,6 +23,8 @@ public class ServiceConfig {
 
     private final String scheduledJobCronShortTimeFrame;
     private final String scheduledJobCronLongTimeFrame;
+    private final String applicationName;
+    private final String applicationVersion;
 
     /**
      * Initializes the configuration.
@@ -32,12 +36,15 @@ public class ServiceConfig {
 
         this.tenants = getMandatoryTenantNames(propertyProvider);
 
+        this.applicationName = propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_NAME);
+        this.applicationVersion = propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_VERSION);
+
         this.scheduledJobCronShortTimeFrame =
-                propertyProvider.getProperty(PropertyProvider.SHORT_TIME_FRAME_SCHEDULED_JOB_CRON)
+                propertyProvider.getProperty(SHORT_TIME_FRAME_SCHEDULED_JOB_CRON)
                         .map(String::valueOf)
                         .orElse("0/30 * * * * ? *");
         this.scheduledJobCronLongTimeFrame =
-                propertyProvider.getProperty(PropertyProvider.LONG_TIME_FRAME_SCHEDULED_JOB_CRON)
+                propertyProvider.getProperty(LONG_TIME_FRAME_SCHEDULED_JOB_CRON)
                         .map(String::valueOf)
                         .orElse("5 0 0/1 * * ? *");
     }
@@ -49,6 +56,16 @@ public class ServiceConfig {
         return tenants;
     }
 
+    @Nonnull
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    @Nonnull
+    public String getApplicationVersion() {
+        return applicationVersion;
+    }
+
     /**
      * Gets the
      * <a href="http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger">QUARTZ cron expression</a>
@@ -56,6 +73,7 @@ public class ServiceConfig {
      *
      * @return the cron expression
      */
+    @Nonnull
     public String getScheduledJobCronForShortTimeFramePoll() {
         return scheduledJobCronShortTimeFrame;
     }
@@ -67,6 +85,7 @@ public class ServiceConfig {
      *
      * @return the cron expression
      */
+    @Nonnull
     public String getScheduledJobCronForLongTimeFramePoll() {
         return scheduledJobCronLongTimeFrame;
     }
@@ -75,10 +94,11 @@ public class ServiceConfig {
      * Split comma or semicolon separated list of the tenants names.
      * <p>
      * All trailing/leading whitespaces are ignored.
+     *
      * @param propertyProvider property provider which supplies {@link PropertyProvider#TENANTS} value.
      * @return non-null non-empty list of tenants.
      * @throws IllegalStateException if the property can't be parsed or the parsed list is empty, or one of the values
-     * is empty (e.g., list of "a, , b").
+     *                               is empty (e.g., list of "a, , b").
      */
     private List<String> getMandatoryTenantNames(PropertyProvider propertyProvider) {
         final String tenantsList = propertyProvider.getMandatoryNonEmptyProperty(PropertyProvider.TENANTS);

--- a/service/src/test/java/com/commercetools/pspadapter/payone/config/PropertyProviderTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/config/PropertyProviderTest.java
@@ -1,0 +1,51 @@
+package com.commercetools.pspadapter.payone.config;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.commercetools.pspadapter.payone.config.PropertyProvider.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyProviderTest {
+
+    private static final String HALLO_TEST_KEY = "hallo-test";
+    private PropertyProvider propertyProvider;
+
+    @Before
+    public void setUp() throws Exception {
+        propertyProvider = new PropertyProvider();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        System.clearProperty(HALLO_TEST_KEY); // in case exception happened in getFromSystemProperties test
+    }
+
+    @Test
+    public void getInternalProperties() throws Exception {
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_API_VERSION)).isEqualTo("3.9");
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_REQUEST_ENCODING)).isEqualTo("UTF-8");
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_SOLUTION_NAME)).isEqualTo("commercetools-platform");
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_SOLUTION_VERSION)).isEqualTo("1");
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_NAME)).isEqualTo("DEBUG-TITLE");
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_VERSION)).isEqualTo("DEBUG-VERSION");
+    }
+
+    @Test
+    public void getEmptyProperties() throws Exception {
+        assertThat(propertyProvider.getProperty(null)).isEmpty();
+        assertThat(propertyProvider.getProperty("")).isEmpty();
+        assertThat(propertyProvider.getProperty("  ")).isEmpty();
+        assertThat(propertyProvider.getProperty("woot-hack-woot")).isEmpty();
+    }
+
+    @Test
+    public void getFromSystemProperties() throws Exception {
+        assertThat(propertyProvider.getProperty("hallo-test")).isEmpty();
+        System.setProperty("hallo-test", "world");
+        assertThat(propertyProvider.getProperty("hallo-test")).contains("world");
+        System.clearProperty(HALLO_TEST_KEY);
+    }
+
+}

--- a/service/src/test/java/com/commercetools/pspadapter/payone/config/ServiceConfigTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/config/ServiceConfigTest.java
@@ -7,7 +7,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Optional;
 
-import static com.commercetools.pspadapter.payone.config.PropertyProvider.TENANTS;
+import static com.commercetools.pspadapter.payone.config.PropertyProvider.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Matchers.anyString;
@@ -66,6 +66,20 @@ public class ServiceConfigTest {
     public void getsSingleTenantName() {
         when(propertyProvider.getProperty(TENANTS)).thenReturn(Optional.of("testTenantName"));
         assertThat(new ServiceConfig(propertyProvider).getTenants()).containsOnly("testTenantName");
+    }
+
+    @Test
+    public void getsApplicationInfo() {
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_NAME)).isEqualTo("DEBUG-TITLE");
+        assertThat(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_VERSION)).isEqualTo("DEBUG-VERSION");
+
+        when(propertyProvider.getProperty(TENANTS)).thenReturn(Optional.of("testTenantName"));
+        when(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_NAME)).thenReturn("testAppName");
+        when(propertyProvider.getMandatoryNonEmptyProperty(PAYONE_INTEGRATOR_VERSION)).thenReturn("testAppVersion");
+
+        ServiceConfig serviceConfig = new ServiceConfig(propertyProvider);
+        assertThat(serviceConfig.getApplicationName()).isEqualTo("testAppName");
+        assertThat(serviceConfig.getApplicationVersion()).isEqualTo("testAppVersion");
     }
 
     @Test


### PR DESCRIPTION
Update `/health` JSON response so it [contains now fields](https://github.com/commercetools/commercetools-payone-integration/pull/188/files#diff-a684bbe1ce55a8f4dea792d69dd8397aR156):
  - `"status": 200` - legacy hardcoded value
  - `"tenants": [...]` - [list of registered tenants name for this application](https://github.com/commercetools/commercetools-payone-integration/pull/188/files#diff-a684bbe1ce55a8f4dea792d69dd8397aR48)
  - `"applicationInfo":{"version": "XXX", "title": "app-name"}` - [version and application name info](https://github.com/commercetools/commercetools-payone-integration/pull/188/files#diff-8405d481fb7e3e4ff137072c1e8384ecR59). The version and title are [built-in into jar](https://github.com/commercetools/commercetools-payone-integration/pull/188/files#diff-c197962302397baf3a4cc36463dce5eaR104) and read at runtime from [package info](https://github.com/commercetools/commercetools-payone-integration/pull/188/files#diff-b5d64dd910cbb85f7c37fc04f12af0baR41)

Respective [functional tests added](https://github.com/commercetools/commercetools-payone-integration/pull/188/files#diff-0b1fbfaad30be0ba9a65fca38260eff1).

addresses issue #176