### PR TITLE
#197: re-factor HttpRequestUtilParallelTest to handle 408 Timeout res…

### DIFF
--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
@@ -3,8 +3,9 @@ package com.commercetools.util;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -14,6 +15,7 @@ import java.util.function.Supplier;
 import static com.commercetools.util.HttpRequestUtil.*;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.apache.http.HttpStatus.SC_REQUEST_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -24,52 +26,108 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class HttpRequestUtilParallelTest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestUtilParallelTest.class);
+
     // try to make 200 simultaneous requests in 200 threads
     private final int nThreads = CONNECTION_MAX_TOTAL;
     private final int requests = CONNECTION_MAX_TOTAL;
 
     @Test
     public void executeGetRequest_shouldBeParalleled() throws Exception {
-        makeParallelRequests(nThreads, requests, () -> {
-            try {
-                final HttpResponse httpResponse = executeGetRequest("http://httpbin.org/get");
-                assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
-                return 1;
-            } catch (IOException e) {
-                throw new RuntimeException("Request exception", e);
-            }
-        });
+        makeAndAssertParallelRequests(nThreads, requests, createRequestsSupplier(
+                () -> executeGetRequest("http://httpbin.org/get"),
+                // in get requests asserted only response status
+                httpResponse -> assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK)));
     }
 
     @Test
     public void executePostRequest_shouldBeParalleled() throws Exception {
-        makeParallelRequests(nThreads, requests, () -> {
-            try {
-                final HttpResponse httpResponse = executePostRequest("http://httpbin.org/post", asList(
+        makeAndAssertParallelRequests(nThreads, requests, createRequestsSupplier(
+                () -> executePostRequest("http://httpbin.org/post", asList(
                         nameValue("xxx", "yyy"),
-                        nameValue("zzz", 11223344)));
-                assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
-                assertThat(responseToString(httpResponse)).contains("xxx", "yyy", "zzz", "11223344");
-                return 1;
-            } catch (IOException e) {
-                throw new RuntimeException("Request exception", e);
-            }
-        });
+                        nameValue("zzz", 11223344))),
+                // in post requests asserted status and body
+                httpResponse -> {
+                    assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+                    assertThat(responseToString(httpResponse)).contains("xxx", "yyy", "zzz", "11223344");
+                }
+        ));
     }
 
-    private void makeParallelRequests(final int nThreads, final int requests, final Supplier<Integer> request) throws Exception {
+    /**
+     * Function to create request/response supplier for GET/POST tests and assert the received response. The result of
+     * this function is used as a supplier for {@link #makeAndAssertParallelRequests(int, int, Supplier)}.
+     * <p>
+     * The function implementation takes care about {@code 408 Timeout} response from
+     * <a href="http://httpbin.org">http://httpbin.org</a>: if such response is received
+     * (when the service is overloaded) - the implementation makes a retry up to 3 times. This is important to avoid
+     * false failures of the tests when <a href="http://httpbin.org">http://httpbin.org</a> is overloaded.
+     *
+     * @param responseSupplier       supplier which when executed makes single blocking request and returns a response.
+     * @param responseAssertConsumer procedure to assert the response obtained from {@code responseSupplier}
+     * @return new supplier which when finished successfully - returns <b>1</b>, otherwise - <b>0</b>.
+     */
+    private Supplier<Integer> createRequestsSupplier(final ExceptionalSupplier<HttpResponse> responseSupplier,
+                                                     final ExceptionalConsumer<HttpResponse> responseAssertConsumer) {
+        return () -> {
+            try {
+                int statusCode;
+                int repeatedTimes = 0;
+                HttpResponse httpResponse;
+                do {
+                    if (repeatedTimes > 0) {
+                        LOGGER.warn("{} \"Request Timeout\" received from [{}]. Retry {} of {} ...",
+                                SC_REQUEST_TIMEOUT, "http://httpbin.org/", repeatedTimes, RETRY_TIMES);
+                    }
+                    httpResponse = responseSupplier.get();
+                    statusCode = httpResponse.getStatusLine().getStatusCode();
+                    repeatedTimes++;
+                    // sometimes httpbin.org returns 408 (timeout) response. Note, this is not a InterruptedIOException
+                    // or ConnectException, thus DefaultHttpRequestRetryHandler re-try won't handle this case.
+                    // That's why in the tests we use this approach to re-try if the server responded successfully,
+                    // but with "408 timeout" response
+                } while (statusCode == SC_REQUEST_TIMEOUT && repeatedTimes <= RETRY_TIMES);
+
+                assertThat(repeatedTimes)
+                        .withFailMessage(format("Retries over-limit: the post request is executed %d times with timeout response %d",
+                                repeatedTimes, SC_REQUEST_TIMEOUT))
+                        .isLessThanOrEqualTo(RETRY_TIMES);
+
+                responseAssertConsumer.accept(httpResponse);
+                return 1;
+            } catch (Exception e) {
+                LOGGER.error("Request exception: {}", e.toString());
+            }
+
+            return 0;
+        };
+    }
+
+    /**
+     * Execute and count {@code requestsNumber} simultaneous (parallel) requests in {@code nThreads} generating them
+     * from {@code requestSupplier}. At the end assert that all {@code requestsNumber} finished successfully, i.e.
+     * exception or timeout not happened.
+     *
+     * @param nThreads        number of parallel requests/threads
+     * @param requestsNumber  total number of requests to execute
+     * @param requestSupplier requests generator: generated requests return <b>1</b> if finished successfully or
+     *                        <b>0</b> otherwise
+     * @throws Exception in case of thread pool exceptions
+     */
+    private void makeAndAssertParallelRequests(final int nThreads, final int requestsNumber,
+                                               final Supplier<Integer> requestSupplier) throws Exception {
         final ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(nThreads);
 
         final AtomicInteger counter = new AtomicInteger(0);
-        for (int i = 0; i < requests; i++) {
-            newFixedThreadPool.execute(() -> counter.addAndGet(request.get()));
+        for (int i = 0; i < requestsNumber; i++) {
+            newFixedThreadPool.execute(() -> counter.addAndGet(requestSupplier.get()));
         }
 
         newFixedThreadPool.shutdown();
 
         // length of the longest pipe in the multi thread pipeline,
         // literally it is an maximum integer number of sequential requests in one pipe (thread)
-        final int criticalPathLength = (int) Math.ceil((double) requests / nThreads);
+        final int criticalPathLength = (int) Math.ceil((double) requestsNumber / nThreads);
 
         // longest expected time of one successful request (even if retried),
         // which may have +RETRY_TIMES attempts additionally to the first (failed) attempt
@@ -83,7 +141,20 @@ public class HttpRequestUtilParallelTest {
                 .withFailMessage(format("The execution thread pool was not able to shutdown in time %s msec", maxCriticalPathDurationMsec))
                 .isTrue();
 
-        assertThat(counter.get()).isEqualTo(requests);
+        assertThat(counter.get())
+                .withFailMessage(format("Incorrect number of finished requests: expected %d, executed %d. " +
+                        "See the standard error logs (stderr) for exceptions", counter.get(), requestsNumber))
+                .isEqualTo(requestsNumber);
     }
 
+    @FunctionalInterface
+    private interface ExceptionalSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface ExceptionalConsumer<T> {
+        void accept(T t) throws Exception;
+
+    }
 }

--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
@@ -96,7 +96,7 @@ public class HttpRequestUtilParallelTest {
                 responseAssertConsumer.accept(httpResponse);
                 return 1;
             } catch (Exception e) {
-                LOGGER.error("Request exception: {}", e.toString());
+                LOGGER.error("Request exception: ", e);
             }
 
             return 0;

--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static com.commercetools.util.HttpRequestUtil.*;
+import static com.commercetools.util.HttpRequestUtilTest.*;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.apache.http.HttpStatus.SC_REQUEST_TIMEOUT;
@@ -35,7 +36,7 @@ public class HttpRequestUtilParallelTest {
     @Test
     public void executeGetRequest_shouldBeParalleled() throws Exception {
         makeAndAssertParallelRequests(nThreads, nRequests, createRequestsSupplier(
-                () -> executeGetRequest("http://httpbin.org/get"),
+                () -> executeGetRequest(HTTP_HTTPBIN_ORG_GET),
                 // in get requests asserted only response status
                 httpResponse -> assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK)));
     }
@@ -43,7 +44,7 @@ public class HttpRequestUtilParallelTest {
     @Test
     public void executePostRequest_shouldBeParalleled() throws Exception {
         makeAndAssertParallelRequests(nThreads, nRequests, createRequestsSupplier(
-                () -> executePostRequest("http://httpbin.org/post", asList(
+                () -> executePostRequest(HTTP_HTTPBIN_ORG_POST, asList(
                         nameValue("xxx", "yyy"),
                         nameValue("zzz", 11223344))),
                 // in post requests asserted status and body
@@ -77,7 +78,7 @@ public class HttpRequestUtilParallelTest {
                 do {
                     if (repeatedTimes > 0) {
                         LOGGER.warn("{} \"Request Timeout\" received from [{}]. Retry {} of {} ...",
-                                SC_REQUEST_TIMEOUT, "http://httpbin.org/", repeatedTimes, RETRY_TIMES);
+                                SC_REQUEST_TIMEOUT, HTTP_HTTPBIN_ORG, repeatedTimes, RETRY_TIMES);
                     }
                     httpResponse = responseSupplier.get();
                     statusCode = httpResponse.getStatusLine().getStatusCode();

--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
@@ -143,7 +143,7 @@ public class HttpRequestUtilParallelTest {
 
         assertThat(counter.get())
                 .withFailMessage(format("Incorrect number of finished requests: expected %d, executed %d. " +
-                        "See the standard error logs (stderr) for exceptions", counter.get(), nRequests))
+                        "Please see the standard error logs (stderr) for exceptions", counter.get(), nRequests))
                 .isEqualTo(nRequests);
     }
 

--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilTest.java
@@ -19,8 +19,9 @@ import static org.assertj.core.data.MapEntry.entry;
 
 public class HttpRequestUtilTest {
 
-    private static final String HTTP_HTTPBIN_ORG_GET = "http://httpbin.org/get";
-    private static final String HTTP_HTTPBIN_ORG_POST = "http://httpbin.org/post";
+    static final String HTTP_HTTPBIN_ORG = "http://httpbin.org/";
+    static final String HTTP_HTTPBIN_ORG_GET = HTTP_HTTPBIN_ORG + "get";
+    static final String HTTP_HTTPBIN_ORG_POST = HTTP_HTTPBIN_ORG + "post";
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 


### PR DESCRIPTION
Addresses #197 issue:
 - implemented re-try strategy for [`HttpRequestUtilParallelTest`](https://github.com/commercetools/commercetools-payone-integration/pull/198/files#diff-68f2f161bb34687ec51123bdbb575269R57) to avoid false failure on _408 Timeout_ response.

Full fix for re-try strategy in `HttpRequestUtil` will come later as a separate solution.