### PR TITLE
Allow pretty print for /health URL

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
@@ -80,7 +80,7 @@ public class IntegrationService {
         Spark.port(port());
 
         // This is a temporary jerry-rig for the load balancer to check connection with the service itself.
-        // For now it just returns a JSON response {"status":200}
+        // For now it just returns a JSON response with status code, tenants list and static application info.
         // It should be expanded to a more real health-checker service, which really performs PAYONE status check.
         // But don't forget, a load balancer may call this URL very often (like 1 per sec),
         // so don't make this request processor heavy, or implement is as independent background service.


### PR DESCRIPTION
Output health response as pretty-formatted JSON, if `pretty` URL query argument is specified.
This is useful for the developers when you have to review, for example, which tenants are registered in current service, or running application version, so instead of:
http://localhost:8080/health
```json
{"status":200,"tenants":["HEROKU_FIRST_TENANT","HEROKU_SECOND_TENANT"],"applicationInfo":{"version":"DEBUG-VERSION","title":"DEBUG-TITLE"}}
```

you have:
http://localhost:8080/health?pretty
```json
{
  "status" : 200,
  "tenants" : [ "HEROKU_FIRST_TENANT", "HEROKU_SECOND_TENANT" ],
  "applicationInfo" : {
    "version" : "DEBUG-VERSION",
    "title" : "DEBUG-TITLE"
  }
}```
