### PR TITLE
209 fix capture transaction status

### DIFF
--- a/docs/Field-Mapping.md
+++ b/docs/Field-Mapping.md
@@ -381,7 +381,7 @@ The matching transaction is found by sequencenumber = interactionId.
 | **`appointed`** | **`pending`** |  **`Authorization`** (must be single transaction in the list) |  **`Pending`** | create an **`Authorization`** if none there | |
 | **`appointed`** | **`completed`** | **`Authorization`** (must be single transaction in the list) | **`Success`** | create an **`Authorization`** if none there | It's important to save transaction **`Success`** state right after `appointed/completed` notification because in most of the shops the orders are created if the last Authorization/Charge transaction is success |
 | **`appointed`** | **`completed`** | *NOT* **`Authorization`** | **`Pending`**  | | |
-| **`capture`** | not set or **`completed`** | **`Charge`** | usually a **`paid`** follows separately (CT **`Pending`**), but on direct debit the **`capture`** already means money flow -> CT **`Success`** | create a **`Charge`** if none with matching sequencenumber there | |
+| **`capture`** | not set or **`completed`** | **`Charge`** | CT **`Success`** | create a **`Charge#Success`** if none with matching sequencenumber there | |
 | **`paid`** | not set or **`completed`** | **`Charge`** | **`Success`** | create a **`Charge`** if no matching one is found. Does not count up the sequence number | |
 | **`underpaid`** | not set or **`completed`** | **`Charge`** | **`Pending`** | create a **`Charge`** if no matching one found | |
 | **`cancelation`** | not set or **`completed`** | new **`Chargeback`** | **`Success`** | see 4.2.6 Sample: authorization, ELV with cancelation to derive formula for amount | |

--- a/service/src/main/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessor.java
@@ -52,7 +52,7 @@ public class CaptureNotificationProcessor extends NotificationProcessorBase {
 
     /**
      * Add {@link ChangeTransactionState} action to {@code actionsBuilder} if current transaction is still in different
-     * state.
+     * from state in {@code notification}.
      */
     protected ImmutableList.Builder<UpdateAction<Payment>> updateChargeTransactionState(
             @Nonnull final Transaction transaction,

--- a/service/src/main/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessor.java
@@ -11,8 +11,10 @@ import com.google.common.collect.ImmutableList;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
 import io.sphere.sdk.utils.MoneyImpl;
 
+import javax.annotation.Nonnull;
 import javax.money.MonetaryAmount;
 import java.util.List;
 
@@ -28,7 +30,7 @@ public class CaptureNotificationProcessor extends NotificationProcessorBase {
         super(tenantFactory, tenantConfig, transactionStateResolver);
     }
 
-        @Override
+    @Override
     protected boolean canProcess(final Notification notification) {
         return NotificationAction.CAPTURE.equals(notification.getTxaction());
     }
@@ -36,29 +38,56 @@ public class CaptureNotificationProcessor extends NotificationProcessorBase {
     @Override
     protected ImmutableList<UpdateAction<Payment>> createPaymentUpdates(final Payment payment,
                                                                         final Notification notification) {
-        final ImmutableList.Builder<UpdateAction<Payment>> listBuilder = ImmutableList.builder();
-        listBuilder.addAll(super.createPaymentUpdates(payment, notification));
+        final ImmutableList.Builder<UpdateAction<Payment>> actionsBuilder = ImmutableList.builder();
+        actionsBuilder.addAll(super.createPaymentUpdates(payment, notification));
 
         final List<Transaction> transactions = payment.getTransactions();
         final String sequenceNumber = toSequenceNumber(notification.getSequencenumber());
 
         return findMatchingTransaction(transactions, TransactionType.CHARGE, sequenceNumber)
-                .map(transaction -> listBuilder.build())
-                .orElseGet(() -> {
-                    final MonetaryAmount amount = MoneyImpl.of(notification.getPrice(), notification.getCurrency());
+                .map(transaction -> updateChargeTransactionState(transaction, notification, actionsBuilder))
+                .orElseGet(() -> createChargeTransaction(notification, actionsBuilder, sequenceNumber))
+                .build();
+    }
 
-                    //For all payment methods that use PayOne preauthorization and capture but only one CTP-charge
-                    //we must not create a second charge transaction
-                    //at the moment that is only "BANK_TRANSFER_ADVANCE"
-                    if (ClearingType.PAYONE_VOR != ClearingType.getClearingTypeByCode(notification.getClearingtype())) {
-                    listBuilder.add(AddTransaction.of(TransactionDraftBuilder.of(TransactionType.CHARGE, amount)
-                            .timestamp(toZonedDateTime(notification))
-                            .state(notification.getTransactionStatus().getCtTransactionState())
-                            .interactionId(sequenceNumber)
-                            .build()));
-                    }
+    /**
+     * Add {@link ChangeTransactionState} action to {@code actionsBuilder} if current transaction is still in different
+     * state.
+     */
+    protected ImmutableList.Builder<UpdateAction<Payment>> updateChargeTransactionState(
+            @Nonnull final Transaction transaction,
+            @Nonnull final Notification notification,
+            @Nonnull final ImmutableList.Builder<UpdateAction<Payment>> actionsBuilder) {
+        final TransactionState newTransactionState = notification.getTransactionStatus().getCtTransactionState();
+        if (transaction.getState() != newTransactionState) {
+            actionsBuilder.add(ChangeTransactionState.of(newTransactionState, transaction.getId()));
+        }
 
-                    return listBuilder.build();
-                });
+        return actionsBuilder;
+    }
+
+    /**
+     * For payments except {@code BANK_TRANSFER-ADVANCE} ({@link ClearingType#PAYONE_VOR}) add {@link AddTransaction}
+     * update action with {@link TransactionType#CHARGE} and state equal to
+     * {@link io.sphere.sdk.payments.TransactionState Notification#getTransactionStatus()#getCtTransactionState()}
+     */
+    protected ImmutableList.Builder<UpdateAction<Payment>> createChargeTransaction(
+            @Nonnull final Notification notification,
+            @Nonnull final ImmutableList.Builder<UpdateAction<Payment>> actionsBuilder,
+            @Nonnull final String sequenceNumber) {
+        final MonetaryAmount amount = MoneyImpl.of(notification.getPrice(), notification.getCurrency());
+
+        //For all payment methods that use PayOne preauthorization and capture but only one CTP-charge
+        //we must not create a second charge transaction
+        //at the moment that is only "BANK_TRANSFER_ADVANCE"
+        if (ClearingType.PAYONE_VOR != ClearingType.getClearingTypeByCode(notification.getClearingtype())) {
+            actionsBuilder.add(AddTransaction.of(TransactionDraftBuilder.of(TransactionType.CHARGE, amount)
+                    .timestamp(toZonedDateTime(notification))
+                    .state(notification.getTransactionStatus().getCtTransactionState())
+                    .interactionId(sequenceNumber)
+                    .build()));
+        }
+
+        return actionsBuilder;
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessor.java
@@ -53,7 +53,7 @@ public class CaptureNotificationProcessor extends NotificationProcessorBase {
                     if (ClearingType.PAYONE_VOR != ClearingType.getClearingTypeByCode(notification.getClearingtype())) {
                     listBuilder.add(AddTransaction.of(TransactionDraftBuilder.of(TransactionType.CHARGE, amount)
                             .timestamp(toZonedDateTime(notification))
-                            .state(TransactionState.PENDING)
+                            .state(notification.getTransactionStatus().getCtTransactionState())
                             .interactionId(sequenceNumber)
                             .build()));
                     }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/UnsupportedTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/UnsupportedTransactionExecutor.java
@@ -17,6 +17,8 @@ import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
 import javax.annotation.Nonnull;
 import java.time.ZonedDateTime;
 
+import static java.lang.String.format;
+
 /**
  * @author Jan Wolter
  * <p>
@@ -45,10 +47,11 @@ public class UnsupportedTransactionExecutor implements TransactionExecutor {
 
         final AddInterfaceInteraction addInterfaceInteraction = AddInterfaceInteraction.ofTypeKeyAndObjects(
                 CustomTypeBuilder.PAYONE_UNSUPPORTED_TRANSACTION,
-                ImmutableMap.<String, Object>of(
+                ImmutableMap.of(
                         CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now(),
                         CustomFieldKeys.TRANSACTION_ID_FIELD, transaction.getId(),
-                        CustomFieldKeys.MESSAGE_FIELD, "Transaction type not supported."));
+                        CustomFieldKeys.MESSAGE_FIELD, format("Transaction type [%s] not supported for payment method [%s].",
+                                transaction.getType(), payment.getPaymentMethodInfo().getMethod())));
 
         return paymentWithCartLike.withPayment(
             client.executeBlocking(

--- a/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/BaseChargedNotificationProcessorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/BaseChargedNotificationProcessorTest.java
@@ -52,7 +52,7 @@ public class BaseChargedNotificationProcessorTest extends BaseNotificationProces
         final List<? extends UpdateAction<Payment>> updateActions = updatePaymentAndGetUpdateActions(payment);
 
         final MonetaryAmount amount = MoneyImpl.of(notification.getPrice(), notification.getCurrency());
-        final AddTransaction transaction = AddTransaction.of(TransactionDraftBuilder
+        final AddTransaction addChargeTransaction = AddTransaction.of(TransactionDraftBuilder
                 .of(TransactionType.CHARGE, amount, timestamp)
                 .state(TransactionState.PENDING)
                 .interactionId(notification.getSequencenumber())
@@ -67,13 +67,17 @@ public class BaseChargedNotificationProcessorTest extends BaseNotificationProces
                 .filteredOn(u -> u.getAction().equals("addTransaction"))
                 .usingElementComparatorOnFields(
                         "transaction.type", "transaction.amount", "transaction.state", "transaction.timestamp")
-                .containsOnlyOnce(transaction);
+                .containsOnlyOnce(addChargeTransaction);
 
         assertStandardUpdateActions(updateActions, interfaceInteraction, statusInterfaceCode, statusInterfaceText);
 
         verifyUpdateOrderActions(payment, expectedPaymentState);
     }
 
+    /**
+     * Cases when the updated by notification transaction is already in expected state, so only status and interface
+     * interaction actions should be added, change transaction state should not be in the updates list.
+     */
     protected void processingPendingNotificationForPendingChargeTransactionDoesNotChangeState(NotificationProcessorBase testee,
                                                                                               PaymentState expectedPaymentState)
             throws Exception {

--- a/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/notification/common/CaptureNotificationProcessorTest.java
@@ -71,7 +71,7 @@ public class CaptureNotificationProcessorTest extends BaseChargedNotificationPro
         //   > Other event-txaction with parameter “transaction_status” may follow (e.g. “paid”, “debit”, ...).
         //   > The new “txaction” can then be “paid/pending”, “paid/completed”, ... or “failed/completed”.
         //
-        // So, even if Payone changes API and such case happens - we expect to switch CT transaction state to PENDING, not SUCCESS.
+        // So, even if Payone changes API and such case happens - we set CT transaction state to PENDING, not SUCCESS.
         super.processingPendingNotificationAboutUnknownTransactionAddsChargeTransactionWithStatePending(testee, ORDER_PAYMENT_STATE);
     }
 


### PR DESCRIPTION
addresses issue #209:

When notification `capture` is received from Payone, we have to set transaction state to `Success` instead of `Pending`, because `capture` means money transferred to the customer.
See [CaptureNotificationProcessor](https://github.com/commercetools/commercetools-payone-integration/pull/211/files#diff-7412916c8bd0808e0e616165c9cc3ed1) class.

Also, if there is no respective `Charge` transaction in the updated payment - [create such a transaction with `Success` state](https://github.com/commercetools/commercetools-payone-integration/pull/211/files#diff-7412916c8bd0808e0e616165c9cc3ed1R74)

[Updated respective tests](https://github.com/commercetools/commercetools-payone-integration/pull/211/files#diff-f0e35d699b64d57c15cf9ef518442b07L88) (only unit, because capture notification never comes on sandbox account). 