### PR TITLE
205 scheduled job test fix

### DIFF
--- a/functionaltests/src/test/java/specs/scheduler/ScheduledJobFixtureHelper.java
+++ b/functionaltests/src/test/java/specs/scheduler/ScheduledJobFixtureHelper.java
@@ -117,10 +117,10 @@ public class ScheduledJobFixtureHelper {
      * scheduled transactions.</li>
      * </ul>
      *
-     * @return 40 (seconds)
+     * @return 59 (seconds)
      */
     public static long waitSecondsTimeout() {
-        return Math.round(30 * 0.95);
+        return Math.round(30 * 1.95);
     }
 
 }

--- a/functionaltests/src/test/java/specs/scheduler/ScheduledJobFixtureHelper.java
+++ b/functionaltests/src/test/java/specs/scheduler/ScheduledJobFixtureHelper.java
@@ -71,7 +71,7 @@ public class ScheduledJobFixtureHelper {
     public MultiValueResult verifyPaymentIsHandled(String paymentName) throws Exception {
         Payment payment = paymentFixture.fetchPaymentByLegibleName(paymentName);
 
-        logger.info("Current payment [{}] create at {}, now is {}",
+        logger.info("Payment id={} created at {}. The current time now is {}",
                 payment.getId(), payment.getCreatedAt().toInstant(), ZonedDateTime.now().toInstant());
 
         // wait once, if necessary

--- a/functionaltests/src/test/java/specs/scheduler/ScheduledJobFixtureHelper.java
+++ b/functionaltests/src/test/java/specs/scheduler/ScheduledJobFixtureHelper.java
@@ -9,6 +9,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import specs.response.BasePaymentFixture;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
 import static java.util.Optional.ofNullable;
 
 /**
@@ -19,29 +23,30 @@ import static java.util.Optional.ofNullable;
  */
 public class ScheduledJobFixtureHelper {
 
-    private static Logger LOG = LoggerFactory.getLogger(ScheduledJobShortFixture.class);
-
     private final BasePaymentFixture paymentFixture;
+    private final Logger logger;
 
     public ScheduledJobFixtureHelper(BasePaymentFixture paymentFixture) {
         this.paymentFixture = paymentFixture;
+        this.logger = LoggerFactory.getLogger(paymentFixture.getClass());
     }
 
     /**
      * Create a payment, but don't handle it
-     * @param paymentName      test payment alias
-     * @param paymentMethod    payone payment method name
-     * @param transactionType  payone payment transaction type
-     * @param centAmount       payment amount
-     * @param currencyCode     payment currency
+     *
+     * @param paymentName     test payment alias
+     * @param paymentMethod   payone payment method name
+     * @param transactionType payone payment transaction type
+     * @param centAmount      payment amount
+     * @param currencyCode    payment currency
      * @return map of created payment properties
      * @throws Exception any exceptions in the tests
      */
     public MultiValueResult createPayment(String paymentName,
-                                                 String paymentMethod,
-                                                 String transactionType,
-                                                 String centAmount,
-                                                 String currencyCode) throws Exception {
+                                          String paymentMethod,
+                                          String transactionType,
+                                          String centAmount,
+                                          String currencyCode) throws Exception {
 
         Payment payment = paymentFixture.createAndSavePayment(paymentName, paymentMethod, transactionType, centAmount, currencyCode);
 
@@ -58,6 +63,7 @@ public class ScheduledJobFixtureHelper {
 
     /**
      * Verify the {@code paymentName} is automatically handled by (short) scheduled task.
+     *
      * @param paymentName payment alias
      * @return map of the payment properties after waiting scheduled task.
      * @throws Exception any exceptions in the tests
@@ -65,18 +71,23 @@ public class ScheduledJobFixtureHelper {
     public MultiValueResult verifyPaymentIsHandled(String paymentName) throws Exception {
         Payment payment = paymentFixture.fetchPaymentByLegibleName(paymentName);
 
+        logger.info("Current payment [{}] create at {}, now is {}",
+                payment.getId(), payment.getCreatedAt().toInstant(), ZonedDateTime.now().toInstant());
+
         // wait once, if necessary
         if (payment.getPaymentStatus() == null || StringUtils.isBlank(payment.getPaymentStatus().getInterfaceCode())) {
 
             // how much time to wait till the next scheduled job is definitely started
-            long secondsToWait = payment.getCreatedAt()
-                    .plusSeconds(waitSecondsTimeout())
-                    .minusSeconds(System.currentTimeMillis() / 1000).toEpochSecond();
+            long secondsToWait = waitSecondsTimeout() -
+                    Duration.between(payment.getCreatedAt(), ZonedDateTime.now()).getSeconds();
 
             if (secondsToWait > 0) {
-                LOG.info("Wait up to {} seconds for scheduled job to run", secondsToWait);
+                logger.info("Wait up to {} seconds for scheduled job to run", secondsToWait);
                 Thread.sleep(secondsToWait * 1000);
             }
+
+            logger.info("{} seconds passed after the payment creation - verify the payment now",
+                    Duration.between(payment.getCreatedAt(), ZonedDateTime.now()).getSeconds());
 
             payment = paymentFixture.fetchPaymentByLegibleName(paymentName);
         }
@@ -86,7 +97,9 @@ public class ScheduledJobFixtureHelper {
                 .with("paymentStatus", ofNullable(payment.getPaymentStatus()).map(PaymentStatus::getInterfaceCode).orElse(null))
                 .with("interfaceInteractionsSize", payment.getInterfaceInteractions().size())
                 .with("transactionsSize", payment.getTransactions().size())
+                .with("createdAt", payment.getCreatedAt())
                 .with("lastModifiedAt", payment.getLastModifiedAt())
+                .with("verifiedAt", Instant.now())
                 .with("hasBeenModified", payment.getCreatedAt().compareTo(payment.getLastModifiedAt()) < 0);
     }
 
@@ -94,17 +107,20 @@ public class ScheduledJobFixtureHelper {
      * A maximum duration we wait for a payment is handled by (short) scheduled task.
      * <p>
      * <b>Note:</b><ul>
-     *     <li>this test is depended on actual service's {@link ServiceConfig#getScheduledJobCronForShortTimeFramePoll()}
+     * <li>this test is depended on actual service's {@link ServiceConfig#getScheduledJobCronForShortTimeFramePoll()}
      * value, which is configured by {@code SHORT_TIME_FRAME_SCHEDULED_JOB_CRON} environment variable
      * (or fallback to default one). We expect the short time-frame is "every 30 seconds" (<b>{@code 0/30 * * * * ? *}</b>.
      * Adjust this value if you change short time-frame schedule in the Heroku service.</li>
-     *     <li>We added 10 second gap to let the job complete if any lags occurred.</li>
+     * <li>We almost double this time gap to let the job complete if any lags occurred.
+     * Also, this is important since the scheduled jobs are sequential (e.g. process every tenant queues one-by-one),
+     * hence second tenant transactions processing is blocked in the queue until the first tenant processes all
+     * scheduled transactions.</li>
      * </ul>
      *
      * @return 40 (seconds)
      */
-    public static int waitSecondsTimeout() {
-        return 40;
+    public static long waitSecondsTimeout() {
+        return Math.round(30 * 0.95);
     }
 
 }

--- a/functionaltests/src/test/java/specs/scheduler/ScheduledJobShort2Fixture.java
+++ b/functionaltests/src/test/java/specs/scheduler/ScheduledJobShort2Fixture.java
@@ -26,7 +26,7 @@ public class ScheduledJobShort2Fixture extends BaseTenant2Fixture {
         return helper.createPayment(paymentName, paymentMethod, transactionType, centAmount, currencyCode);
     }
 
-    public static int waitSecondsTimeout() {
+    public static long waitSecondsTimeout() {
         return ScheduledJobFixtureHelper.waitSecondsTimeout();
     }
 

--- a/functionaltests/src/test/java/specs/scheduler/ScheduledJobShortFixture.java
+++ b/functionaltests/src/test/java/specs/scheduler/ScheduledJobShortFixture.java
@@ -26,7 +26,7 @@ public class ScheduledJobShortFixture extends BasePaymentFixture {
         return helper.createPayment(paymentName, paymentMethod, transactionType, centAmount, currencyCode);
     }
 
-    public static int waitSecondsTimeout() {
+    public static long waitSecondsTimeout() {
         return ScheduledJobFixtureHelper.waitSecondsTimeout();
     }
 

--- a/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort.html
+++ b/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort.html
@@ -32,8 +32,8 @@
             <th c:assertEquals="#paymentResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#paymentResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#paymentResult.transactionsSize">Transactions</th>
-            <th c:echo="#paymentResult.createdAt">Created at (FIO)</th>
-            <th c:echo="#paymentResult.lastModifiedAt">Last modified at (FIO)</th>
+            <th c:echo="#paymentResult.createdAt">Created At (FIO)</th>
+            <th c:echo="#paymentResult.lastModifiedAt">Last Modified At (FIO)</th>
             <th c:assertEquals="#paymentResult.isNotModified">Is not modified?</th>
         </tr>
         <tr>
@@ -76,7 +76,9 @@
             <th c:assertEquals="#verifyResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#verifyResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#verifyResult.transactionsSize">Transactions</th>
-            <th c:echo="#verifyResult.lastModifiedAt">Interface Interactions</th>
+            <th c:echo="#verifyResult.createdAt">Created At (FIO)</th>
+            <th c:echo="#verifyResult.lastModifiedAt">Last Modified At (FIO)</th>
+            <th c:echo="#verifyResult.verifiedAt">Verified At (FIO)</th>
             <th c:assertEquals="#verifyResult.hasBeenModified">Has been modified?</th>
         </tr>
         <tr>
@@ -86,6 +88,8 @@
             <td>2</td>
             <td>1</td>
             <td></td>
+            <td></td>
+            <td></td>
             <td>true</td>
         </tr>
         <tr>
@@ -94,6 +98,8 @@
             <td>REDIRECT</td>
             <td>2</td>
             <td>1</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>true</td>
         </tr>

--- a/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort.html
+++ b/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort.html
@@ -32,8 +32,8 @@
             <th c:assertEquals="#paymentResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#paymentResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#paymentResult.transactionsSize">Transactions</th>
-            <th c:echo="#paymentResult.createdAt">Created At (FIO)</th>
-            <th c:echo="#paymentResult.lastModifiedAt">Last Modified At (FIO)</th>
+            <th c:echo="#paymentResult.createdAt">Created at (FIO)</th>
+            <th c:echo="#paymentResult.lastModifiedAt">Last Modified at (FIO)</th>
             <th c:assertEquals="#paymentResult.isNotModified">Is not modified?</th>
         </tr>
         <tr>
@@ -76,9 +76,9 @@
             <th c:assertEquals="#verifyResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#verifyResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#verifyResult.transactionsSize">Transactions</th>
-            <th c:echo="#verifyResult.createdAt">Created At (FIO)</th>
-            <th c:echo="#verifyResult.lastModifiedAt">Last Modified At (FIO)</th>
-            <th c:echo="#verifyResult.verifiedAt">Verified At (FIO)</th>
+            <th c:echo="#verifyResult.createdAt">Created at (FIO)</th>
+            <th c:echo="#verifyResult.lastModifiedAt">Last Modified at (FIO)</th>
+            <th c:echo="#verifyResult.verifiedAt">Verified at (FIO)</th>
             <th c:assertEquals="#verifyResult.hasBeenModified">Has been modified?</th>
         </tr>
         <tr>

--- a/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort2.html
+++ b/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort2.html
@@ -32,8 +32,8 @@
             <th c:assertEquals="#paymentResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#paymentResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#paymentResult.transactionsSize">Transactions</th>
-            <th c:echo="#paymentResult.createdAt">Created At (FIO)</th>
-            <th c:echo="#paymentResult.lastModifiedAt">Last Modified At (FIO)</th>
+            <th c:echo="#paymentResult.createdAt">Created at (FIO)</th>
+            <th c:echo="#paymentResult.lastModifiedAt">Last Modified at (FIO)</th>
             <th c:assertEquals="#paymentResult.isNotModified">Is not modified?</th>
         </tr>
         <tr>
@@ -61,9 +61,9 @@
             <th c:assertEquals="#verifyResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#verifyResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#verifyResult.transactionsSize">Transactions</th>
-            <th c:echo="#verifyResult.createdAt">Created At (FIO)</th>
-            <th c:echo="#verifyResult.lastModifiedAt">Last Modified At (FIO)</th>
-            <th c:echo="#verifyResult.verifiedAt">Verified At (FIO)</th>
+            <th c:echo="#verifyResult.createdAt">Created at (FIO)</th>
+            <th c:echo="#verifyResult.lastModifiedAt">Last Modified at (FIO)</th>
+            <th c:echo="#verifyResult.verifiedAt">Verified at (FIO)</th>
             <th c:assertEquals="#verifyResult.hasBeenModified">Has been modified?</th>
         </tr>
         <tr>

--- a/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort2.html
+++ b/functionaltests/src/test/resources/specs/scheduler/ScheduledJobShort2.html
@@ -32,8 +32,8 @@
             <th c:assertEquals="#paymentResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#paymentResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#paymentResult.transactionsSize">Transactions</th>
-            <th c:echo="#paymentResult.createdAt">Created at (FIO)</th>
-            <th c:echo="#paymentResult.lastModifiedAt">Last modified at (FIO)</th>
+            <th c:echo="#paymentResult.createdAt">Created At (FIO)</th>
+            <th c:echo="#paymentResult.lastModifiedAt">Last Modified At (FIO)</th>
             <th c:assertEquals="#paymentResult.isNotModified">Is not modified?</th>
         </tr>
         <tr>
@@ -61,7 +61,9 @@
             <th c:assertEquals="#verifyResult.paymentStatus">Payment Status</th>
             <th c:assertEquals="#verifyResult.interfaceInteractionsSize">Interface Interactions</th>
             <th c:assertEquals="#verifyResult.transactionsSize">Transactions</th>
-            <th c:echo="#verifyResult.lastModifiedAt">Interface Interactions</th>
+            <th c:echo="#verifyResult.createdAt">Created At (FIO)</th>
+            <th c:echo="#verifyResult.lastModifiedAt">Last Modified At (FIO)</th>
+            <th c:echo="#verifyResult.verifiedAt">Verified At (FIO)</th>
             <th c:assertEquals="#verifyResult.hasBeenModified">Has been modified?</th>
         </tr>
         <tr>
@@ -70,6 +72,8 @@
             <td>APPROVED</td>
             <td>2</td>
             <td>1</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>true</td>
         </tr>


### PR DESCRIPTION
Make the integration test of scheduled job more stable: [increase waiting timeout](https://github.com/commercetools/commercetools-payone-integration/pull/215/files#diff-7b0194e26c1b0d2b9f1082b0b773db8dR122) because scheduled jobs are sequential and thus may take longer then just 30 seconds to update 2 tenants in a row.

Partially fixes #205 (ScheduledJobShort2 fails very often because the payment is sill not APPROVED after waiting timeout, but later it becomes approved)