### PR TITLE
#217: support AUTHORIZATION and CHARGE for all payment types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     apply plugin: 'java'
 
     group = 'com.commercetools'
-    version = '2.2.0-dev' // this version is used in shadowJar.manifest.Implementation-Version and then at runtime as getImplementationVersion()
+    version = '2.3.0-dev' // this version is used in shadowJar.manifest.Implementation-Version and then at runtime as getImplementationVersion()
 
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentDispatcher.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentDispatcher.java
@@ -8,9 +8,8 @@ import io.sphere.sdk.payments.PaymentMethodInfo;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
 
-public class PaymentDispatcher implements Consumer<PaymentWithCartLike> {
+public class PaymentDispatcher {
 
     private final Map<PaymentMethod, PaymentMethodDispatcher> methodDispatcher;
 
@@ -20,11 +19,6 @@ public class PaymentDispatcher implements Consumer<PaymentWithCartLike> {
                              final String payoneInterfaceName) {
         this.methodDispatcher = methodDispatcher;
         this.payoneInterfaceName = payoneInterfaceName;
-    }
-
-    @Override
-    public void accept(PaymentWithCartLike paymentWithCartLike) {
-        dispatchPayment(paymentWithCartLike);
     }
 
     public PaymentWithCartLike dispatchPayment(PaymentWithCartLike paymentWithCartLike) {

--- a/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
@@ -43,7 +43,7 @@ public abstract class ScheduledJob implements Job {
             final Consumer<Payment> paymentConsumer = payment -> {
                 try {
                     final PaymentWithCartLike paymentWithCartLike = queryExecutor.getPaymentWithCartLike(payment.getId(), CompletableFuture.completedFuture(payment));
-                    paymentDispatcher.accept(paymentWithCartLike);
+                    paymentDispatcher.dispatchPayment(paymentWithCartLike);
                 } catch (final NoCartLikeFoundException ex) {
                     LOG.debug(LOG_PREFIX + " Could not dispatch payment with ID \"{}\": {}",
                             tenantFactory.getTenantName(),  payment.getId(), ex.getMessage());

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
@@ -1,8 +1,5 @@
 package com.commercetools.pspadapter.payone.domain.ctp.paymentmethods;
 
-import com.google.common.collect.ImmutableSet;
-import io.sphere.sdk.payments.TransactionType;
-
 import javax.annotation.Nonnull;
 
 import static java.util.Arrays.stream;
@@ -17,83 +14,56 @@ public enum PaymentMethod {
     /**
      * @see MethodKeys#DIRECT_DEBIT_SEPA
      */
-    DIRECT_DEBIT_SEPA(MethodKeys.DIRECT_DEBIT_SEPA,
-                    TransactionType.AUTHORIZATION
-    ),
+    DIRECT_DEBIT_SEPA(MethodKeys.DIRECT_DEBIT_SEPA),
 
     /**
      * @see MethodKeys#CREDIT_CARD
      */
-    CREDIT_CARD(MethodKeys.CREDIT_CARD,
-                    TransactionType.AUTHORIZATION,
-                    TransactionType.CHARGE
-    ),
+    CREDIT_CARD(MethodKeys.CREDIT_CARD),
 
     /**
      * @see MethodKeys#WALLET_PAYPAL
      */
-    WALLET_PAYPAL(MethodKeys.WALLET_PAYPAL,
-                    TransactionType.AUTHORIZATION,
-                    TransactionType.CHARGE),
+    WALLET_PAYPAL(MethodKeys.WALLET_PAYPAL),
 
     /**
      * @see MethodKeys#BANK_TRANSFER_SOFORTUEBERWEISUNG
      */
-    BANK_TRANSFER_SOFORTUEBERWEISUNG(MethodKeys.BANK_TRANSFER_SOFORTUEBERWEISUNG,
-                    TransactionType.CHARGE
-    ),
+    BANK_TRANSFER_SOFORTUEBERWEISUNG(MethodKeys.BANK_TRANSFER_SOFORTUEBERWEISUNG),
 
     /**
      * @see MethodKeys#BANK_TRANSFER_ADVANCE
      */
-    BANK_TRANSFER_ADVANCE(MethodKeys.BANK_TRANSFER_ADVANCE,
-                    TransactionType.CHARGE
-    ),
+    BANK_TRANSFER_ADVANCE(MethodKeys.BANK_TRANSFER_ADVANCE),
 
     /**
      * @see MethodKeys#BANK_TRANSFER_SOFORTUEBERWEISUNG
      */
-    BANK_TRANSFER_POSTFINANCE_EFINANCE(MethodKeys.BANK_TRANSFER_POSTFINANCE_EFINANCE,
-            TransactionType.CHARGE
-    ),
+    BANK_TRANSFER_POSTFINANCE_EFINANCE(MethodKeys.BANK_TRANSFER_POSTFINANCE_EFINANCE),
 
     /**
      * @see MethodKeys#BANK_TRANSFER_SOFORTUEBERWEISUNG
      */
-    BANK_TRANSFER_POSTFINANCE_CARD(MethodKeys.BANK_TRANSFER_POSTFINANCE_CARD,
-            TransactionType.CHARGE
-    ),
+    BANK_TRANSFER_POSTFINANCE_CARD(MethodKeys.BANK_TRANSFER_POSTFINANCE_CARD),
 
     /**
      * @see MethodKeys#INVOICE_KLARNA
      */
-    INVOICE_KLARNA(MethodKeys.INVOICE_KLARNA,
-            // based on Payone support talk: only "preauthorization" transaction type should be use
-            TransactionType.AUTHORIZATION
-    );
+    INVOICE_KLARNA(MethodKeys.INVOICE_KLARNA);
 
     private String key;
-    private ImmutableSet<TransactionType> supportedTransactionTypes;
 
-    PaymentMethod(final String key, final TransactionType... supportedTransactionTypes) {
+    PaymentMethod(final String key) {
         this.key = key;
-        this.supportedTransactionTypes = ImmutableSet.copyOf(supportedTransactionTypes);
     }
 
     /**
      * Gets the method key.
+     *
      * @return the method key, never null
      */
     public String getKey() {
         return key;
-    }
-
-    /**
-     * Gets the transaction types supported by this payment method.
-     * @return the supported transaction types, never null
-     */
-    public ImmutableSet<TransactionType> getSupportedTransactionTypes() {
-        return supportedTransactionTypes;
     }
 
     /**

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
@@ -72,7 +72,7 @@ public enum PaymentMethod {
      * Make transaction type handling transparent</a></i>
      * we support any {@link TransactionType#AUTHORIZATION AUTHORIZATION} or {@link TransactionType#CHARGE CHARGE}
      * transaction for all payment methods: the Payone request will be sent without additional validation.
-     * It is a responsibility of
+     * It is a responsibility of payment creator (shop developers).
      * Although, other transaction types (like {@code REFUND} or {@code CANCEL_AUTHORIZATION}) are not supported yet.
      */
     public static final ImmutableSet<TransactionType> supportedTransactionTypes = ImmutableSet.of(AUTHORIZATION, CHARGE);

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethod.java
@@ -1,20 +1,27 @@
 package com.commercetools.pspadapter.payone.domain.ctp.paymentmethods;
 
-import javax.annotation.Nonnull;
+import com.google.common.collect.ImmutableSet;
+import io.sphere.sdk.payments.TransactionType;
 
+import javax.annotation.Nonnull;
+import java.util.EnumSet;
+
+import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
 import static java.util.Arrays.stream;
 
 /**
- * Enumerates the payment methods available for Payone.
+ * Enumerates the payment methods available for Payone and <b>supported by current service</b>.
  *
  * @see MethodKeys
  */
 public enum PaymentMethod {
 
-    /**
-     * @see MethodKeys#DIRECT_DEBIT_SEPA
-     */
-    DIRECT_DEBIT_SEPA(MethodKeys.DIRECT_DEBIT_SEPA),
+//    /**
+//     * <b>Neither implemented, nor tested yet!</b>
+//     * @see MethodKeys#DIRECT_DEBIT_SEPA
+//     */
+//    DIRECT_DEBIT_SEPA(MethodKeys.DIRECT_DEBIT_SEPA),
 
     /**
      * @see MethodKeys#CREDIT_CARD
@@ -50,6 +57,25 @@ public enum PaymentMethod {
      * @see MethodKeys#INVOICE_KLARNA
      */
     INVOICE_KLARNA(MethodKeys.INVOICE_KLARNA);
+
+    /**
+     * Set of payment methods supported by the integration service.
+     * Other payment methods are not supported so far and will throw an exception.
+     */
+    public static final EnumSet<PaymentMethod> supportedPaymentMethods = EnumSet.allOf(PaymentMethod.class);
+
+    /**
+     * Set of supported CTP transaction types.
+     * <p>
+     * <b>Note:</b> solving issue
+     * <i><a href="https://github.com/commercetools/commercetools-payone-integration/issues/217">
+     * Make transaction type handling transparent</a></i>
+     * we support any {@link TransactionType#AUTHORIZATION AUTHORIZATION} or {@link TransactionType#CHARGE CHARGE}
+     * transaction for all payment methods: the Payone request will be sent without additional validation.
+     * It is a responsibility of
+     * Although, other transaction types (like {@code REFUND} or {@code CANCEL_AUTHORIZATION}) are not supported yet.
+     */
+    public static final ImmutableSet<TransactionType> supportedTransactionTypes = ImmutableSet.of(AUTHORIZATION, CHARGE);
 
     private String key;
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferRequest.java
@@ -6,11 +6,15 @@ import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingTy
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
 
+import javax.annotation.Nonnull;
+
 /**
+ * Common bank-transfer specific Payone requests.
+ *
  * @author fhaertig
  * @since 22.01.16
  */
-public class BankTransferAuthorizationRequest extends AuthorizationRequest {
+public class BankTransferRequest extends AuthorizationRequest {
 
     private String onlinebanktransfertype;
 
@@ -22,8 +26,18 @@ public class BankTransferAuthorizationRequest extends AuthorizationRequest {
     @ClearSecuredValuesSerializer.Apply
     private String bic;
 
-    public BankTransferAuthorizationRequest(final PayoneConfig config, final String onlinebanktransfertype) {
-        super(config, RequestType.AUTHORIZATION.getType(), ClearingType.PAYONE_PNT.getPayoneCode());
+    /**
+     * Create basic bank-transfer specific request.
+     *
+     * @param requestType            now only {@link RequestType#PREAUTHORIZATION} and
+     *                               {@link RequestType#AUTHORIZATION} supported.
+     * @param config                 Payone config to use
+     * @param onlinebanktransfertype {@code onlinebanktransfertype} of the Payone bank-transfer request
+     */
+    public BankTransferRequest(@Nonnull final RequestType requestType,
+                               @Nonnull final PayoneConfig config,
+                               @Nonnull final String onlinebanktransfertype) {
+        super(config, requestType.getType(), ClearingType.PAYONE_PNT.getPayoneCode());
 
         this.onlinebanktransfertype = onlinebanktransfertype;
     }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/paymentinadvance/BankTransferInAdvanceRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/paymentinadvance/BankTransferInAdvanceRequest.java
@@ -5,16 +5,15 @@ import com.commercetools.pspadapter.payone.domain.payone.model.common.Authorizat
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 
+import javax.annotation.Nonnull;
+
 /**
- * Due to the type of the CTP-Transaction we create a
  * @author mht@dotsource.de
- *
  */
-public class BankTransferInAdvancePreautorizationRequest extends AuthorizationRequest {
+public class BankTransferInAdvanceRequest extends AuthorizationRequest {
 
-
-    //CashInAdvance only allow PreAuthorization in the wording of payone
-    public BankTransferInAdvancePreautorizationRequest(PayoneConfig config, String clearingtype) {
-        super(config, RequestType.PREAUTHORIZATION.getType(), ClearingType.PAYONE_VOR.getPayoneCode());
+    public BankTransferInAdvanceRequest(@Nonnull RequestType requestType,
+                                        @Nonnull PayoneConfig config) {
+        super(config, requestType.getType(), ClearingType.PAYONE_VOR.getPayoneCode());
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
@@ -25,8 +25,8 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
         super(tenantConfig);
     }
 
-    @Override
     @Nonnull
+    @Override
     public BankTransferInAdvanceRequest createPreauthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
         return createRequestInternal(RequestType.PREAUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
     }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
@@ -2,7 +2,6 @@ package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.CaptureRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvanceCaptureRequest;
@@ -34,7 +33,7 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
 
     @Nonnull
     @Override
-    public AuthorizationRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+    public BankTransferInAdvanceRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
         return createRequestInternal(RequestType.AUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.CaptureRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvanceCaptureRequest;
@@ -24,7 +25,8 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
     }
 
     @Override
-    public BankTransferInAdvancePreautorizationRequest createPreauthorizationRequest(PaymentWithCartLike paymentWithCartLike) {
+    @Nonnull
+    public BankTransferInAdvancePreautorizationRequest createPreauthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
         final Payment ctPayment = paymentWithCartLike.getPayment();
 
         Preconditions.checkArgument(ctPayment.getCustom() != null, "Missing custom fields on payment!");

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BanktTransferInAdvanceRequestFactory.java
@@ -1,17 +1,19 @@
 package com.commercetools.pspadapter.payone.mapping;
 
+import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.CaptureRequest;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvanceCaptureRequest;
-import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvancePreautorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvanceRequest;
 import com.commercetools.pspadapter.tenant.TenantConfig;
 import com.google.common.base.Preconditions;
 import io.sphere.sdk.payments.Payment;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
@@ -26,16 +28,26 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
 
     @Override
     @Nonnull
-    public BankTransferInAdvancePreautorizationRequest createPreauthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+    public BankTransferInAdvanceRequest createPreauthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+        return createRequestInternal(RequestType.PREAUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
+    }
+
+    @Nonnull
+    @Override
+    public AuthorizationRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+        return createRequestInternal(RequestType.AUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
+    }
+
+    @Nonnull
+    public BankTransferInAdvanceRequest createRequestInternal(
+            @Nonnull final RequestType requestType,
+            @Nonnull final PaymentWithCartLike paymentWithCartLike,
+            @Nonnull final BiFunction<RequestType, PayoneConfig, BankTransferInAdvanceRequest> requestConstructor) {
+
         final Payment ctPayment = paymentWithCartLike.getPayment();
-
         Preconditions.checkArgument(ctPayment.getCustom() != null, "Missing custom fields on payment!");
-
-        final String clearingSubType = ClearingType.getClearingTypeByKey(ctPayment.getPaymentMethodInfo().getMethod()).getSubType();
-        BankTransferInAdvancePreautorizationRequest request = new BankTransferInAdvancePreautorizationRequest(getPayoneConfig(), clearingSubType);
-
+        BankTransferInAdvanceRequest request = requestConstructor.apply(requestType, getPayoneConfig());
         mapFormPaymentWithCartLike(request, paymentWithCartLike);
-
         return request;
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CreditCardRequestFactory.java
@@ -24,8 +24,9 @@ public class CreditCardRequestFactory extends PayoneRequestFactory {
     }
 
     @Override
+    @Nonnull
     public CreditCardPreauthorizationRequest createPreauthorizationRequest(
-            final PaymentWithCartLike paymentWithCartLike) {
+            @Nonnull final PaymentWithCartLike paymentWithCartLike) {
 
         final Payment ctPayment = paymentWithCartLike.getPayment();
 
@@ -41,7 +42,7 @@ public class CreditCardRequestFactory extends PayoneRequestFactory {
 
     @Override
     @Nonnull
-    public CreditCardAuthorizationRequest createAuthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    public CreditCardAuthorizationRequest createAuthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
 
         final Payment ctPayment = paymentWithCartLike.getPayment();
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
@@ -41,12 +41,13 @@ public abstract class PayoneRequestFactory {
         this.logger = LoggerFactory.getLogger(createLoggerName(this.getClass(), tenantConfig.getName()));
     }
 
-    public AuthorizationRequest createPreauthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    @Nonnull
+    public AuthorizationRequest createPreauthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
         throw new UnsupportedOperationException("this request type is not supported by this payment method.");
     }
 
     @Nonnull
-    public AuthorizationRequest createAuthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    public AuthorizationRequest createAuthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
         throw new UnsupportedOperationException("this request type is not supported by this payment method.");
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PaypalRequestFactory.java
@@ -21,7 +21,8 @@ public class PaypalRequestFactory extends PayoneRequestFactory {
     }
 
     @Override
-    public WalletPreauthorizationRequest createPreauthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    @Nonnull
+    public WalletPreauthorizationRequest createPreauthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
 
         final Payment ctPayment = paymentWithCartLike.getPayment();
 
@@ -37,7 +38,7 @@ public class PaypalRequestFactory extends PayoneRequestFactory {
 
     @Override
     @Nonnull
-    public WalletAuthorizationRequest createAuthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    public WalletAuthorizationRequest createAuthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
 
         final Payment ctPayment = paymentWithCartLike.getPayment();
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PostFinanceBanktransferRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PostFinanceBanktransferRequestFactory.java
@@ -1,7 +1,7 @@
 package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferRequest;
 import com.commercetools.pspadapter.tenant.TenantConfig;
 
 import javax.annotation.Nonnull;
@@ -17,8 +17,8 @@ public class PostFinanceBanktransferRequestFactory extends BankTransferWithoutIb
 
     @Override
     @Nonnull
-    public BankTransferAuthorizationRequest createAuthorizationRequest(PaymentWithCartLike paymentWithCartLike) {
-        final BankTransferAuthorizationRequest request = super.createAuthorizationRequest(paymentWithCartLike);
+    public BankTransferRequest createAuthorizationRequest(PaymentWithCartLike paymentWithCartLike) {
+        final BankTransferRequest request = super.createAuthorizationRequest(paymentWithCartLike);
         //Despite declared as optional in PayOne Server API documentation. this is required!
         request.setBankcountry("CH");
         return request;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/klarna/KlarnaRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/klarna/KlarnaRequestFactory.java
@@ -11,6 +11,7 @@ import com.commercetools.pspadapter.payone.mapping.CountryToLanguageMapper;
 import com.commercetools.pspadapter.payone.mapping.MappingUtil;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.commercetools.pspadapter.tenant.TenantConfig;
+import com.commercetools.util.function.TriFunction;
 import com.google.common.base.Preconditions;
 import io.sphere.sdk.carts.CartLike;
 import io.sphere.sdk.models.Address;
@@ -40,7 +41,8 @@ public class KlarnaRequestFactory extends PayoneRequestFactory {
     }
 
     @Override
-    public KlarnaPreauthorizationRequest createPreauthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    @Nonnull
+    public KlarnaPreauthorizationRequest createPreauthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
         return createRequestInternal(paymentWithCartLike, KlarnaPreauthorizationRequest::new);
     }
 
@@ -49,13 +51,13 @@ public class KlarnaRequestFactory extends PayoneRequestFactory {
      */
     @Override
     @Nonnull
-    public KlarnaAuthorizationRequest createAuthorizationRequest(final PaymentWithCartLike paymentWithCartLike) {
+    public KlarnaAuthorizationRequest createAuthorizationRequest(@Nonnull final PaymentWithCartLike paymentWithCartLike) {
         return createRequestInternal(paymentWithCartLike, KlarnaAuthorizationRequest::new);
     }
 
     @Nonnull
-    protected <BKR extends BaseKlarnaRequest> BKR createRequestInternal(final PaymentWithCartLike paymentWithCartLike,
-                                                                        final TriFunction<PayoneConfig, String, PaymentWithCartLike, BKR> requestConstructor) {
+    protected <BKR extends BaseKlarnaRequest> BKR createRequestInternal(@Nonnull final PaymentWithCartLike paymentWithCartLike,
+                                                                        @Nonnull final TriFunction<PayoneConfig, String, PaymentWithCartLike, BKR> requestConstructor) {
         final Payment ctPayment = paymentWithCartLike.getPayment();
         Preconditions.checkArgument(ctPayment.getCustom() != null, "Missing custom fields on payment!");
 
@@ -156,10 +158,5 @@ public class KlarnaRequestFactory extends PayoneRequestFactory {
                                 .flatMap(countryToLanguageMapper::mapCountryToLanguage))
                 .map(Locale::getLanguage)
                 .ifPresent(request::setLanguage);
-    }
-
-    @FunctionalInterface
-    private interface TriFunction<T, U, V, R> {
-        R apply(T t, U u, V v);
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceAuthorizationTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceAuthorizationTransactionExecutor.java
@@ -1,0 +1,29 @@
+package com.commercetools.pspadapter.payone.transaction.paymentinadvance;
+
+import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
+import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
+import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
+import com.google.common.cache.LoadingCache;
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.types.Type;
+
+import javax.annotation.Nonnull;
+
+import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
+
+public class BankTransferInAdvanceAuthorizationTransactionExecutor extends BaseBankTransferInAdvanceTransactionExecutor {
+
+    public BankTransferInAdvanceAuthorizationTransactionExecutor(@Nonnull LoadingCache<String, Type> typeCache,
+                                                                 @Nonnull PayoneRequestFactory requestFactory,
+                                                                 @Nonnull PayonePostService payonePostService,
+                                                                 @Nonnull BlockingSphereClient client) {
+        super(AUTHORIZATION, typeCache, requestFactory, payonePostService, client);
+    }
+
+    @Nonnull
+    @Override
+    protected AuthorizationRequest createRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+        return requestFactory.createPreauthorizationRequest(paymentWithCartLike);
+    }
+}

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
@@ -1,185 +1,29 @@
 package com.commercetools.pspadapter.payone.transaction.paymentinadvance;
 
-import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
-import com.commercetools.pspadapter.payone.domain.payone.exceptions.PayoneException;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
-import com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus;
-import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.commercetools.pspadapter.payone.transaction.TransactionBaseExecutor;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.client.BlockingSphereClient;
-import io.sphere.sdk.commands.UpdateActionImpl;
-import io.sphere.sdk.payments.Payment;
-import io.sphere.sdk.payments.Transaction;
-import io.sphere.sdk.payments.TransactionState;
-import io.sphere.sdk.payments.TransactionType;
-import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
-import io.sphere.sdk.payments.commands.updateactions.AddInterfaceInteraction;
-import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionInteractionId;
-import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
-import io.sphere.sdk.payments.commands.updateactions.SetCustomField;
-import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.time.ZonedDateTime;
-import java.util.ConcurrentModificationException;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
-import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.*;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
-/**
- * Responsible to create the PayOne Request (PreAuthorization) and check if answer is approved or Error
- * @author mht@dotsource.de
- *
- */
-public class BankTransferInAdvanceChargeTransactionExecutor extends TransactionBaseExecutor {
+public class BankTransferInAdvanceChargeTransactionExecutor extends BaseBankTransferInAdvanceTransactionExecutor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BankTransferInAdvanceChargeTransactionExecutor.class);
-
-    private final PayoneRequestFactory requestFactory;
-    private final PayonePostService payonePostService;
-
-    public BankTransferInAdvanceChargeTransactionExecutor(@Nonnull final LoadingCache<String, Type> typeCache,
-                                                          @Nonnull final PayoneRequestFactory requestFactory,
-                                                          @Nonnull final PayonePostService payonePostService,
-                                                          @Nonnull final BlockingSphereClient client) {
-        super(typeCache, client);
-        this.requestFactory = requestFactory;
-        this.payonePostService = payonePostService;
+    public BankTransferInAdvanceChargeTransactionExecutor(@Nonnull LoadingCache<String, Type> typeCache,
+                                                          @Nonnull PayoneRequestFactory requestFactory,
+                                                          @Nonnull PayonePostService payonePostService,
+                                                          @Nonnull BlockingSphereClient client) {
+        super(CHARGE, typeCache, requestFactory, payonePostService, client);
     }
 
-    @Override
-    public TransactionType supportedTransactionType() {
-        return TransactionType.CHARGE;
-    }
-
-    @Override
-    protected boolean wasExecuted(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
-        if (getCustomFieldsOfType(paymentWithCartLike,
-                CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE)
-                .noneMatch(fields -> transaction.getId().equals(fields.getFieldAsString(CustomFieldKeys.TRANSACTION_ID_FIELD)))) {
-
-            return getCustomFieldsOfType(paymentWithCartLike, CustomTypeBuilder.PAYONE_INTERACTION_NOTIFICATION)
-                    //sequenceNumber field is mandatory -> can't be null
-                    .anyMatch(fields -> fields.getFieldAsString(CustomFieldKeys.SEQUENCE_NUMBER_FIELD).equals(transaction.getInteractionId()));
-        } else {
-            return true;
-        }
-    }
-
-    @Override
-    public Optional<CustomFields> findLastExecutionAttempt(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
-        return getCustomFieldsOfType(paymentWithCartLike, CustomTypeBuilder.PAYONE_INTERACTION_REQUEST)
-            .filter(i -> i.getFieldAsString(CustomFieldKeys.TRANSACTION_ID_FIELD).equals(transaction.getId()))
-            .reduce((previous, current) -> current);
-    }
-
-    @Override
     @Nonnull
-    public PaymentWithCartLike retryLastExecutionAttempt(@Nonnull PaymentWithCartLike paymentWithCartLike,
-                                                         @Nonnull Transaction transaction,
-                                                         @Nonnull CustomFields lastExecutionAttempt) {
-        if (lastExecutionAttempt.getFieldAsDateTime(CustomFieldKeys.TIMESTAMP_FIELD).isBefore(ZonedDateTime.now().minusMinutes(5))) {
-            return attemptExecution(paymentWithCartLike, transaction);
-        }
-        else {
-            if (lastExecutionAttempt.getFieldAsDateTime(CustomFieldKeys.TIMESTAMP_FIELD).isAfter(ZonedDateTime.now().minusMinutes(1)))
-                throw new ConcurrentModificationException( String.format(
-                        "A processing of payment with ID \"%s\" started during the last 60 seconds and is likely to be finished soon, no need to retry now.",
-                        paymentWithCartLike.getPayment().getId()));
-        }
-        return paymentWithCartLike;
-    }
-
     @Override
-    @Nonnull
-    protected PaymentWithCartLike attemptExecution(final PaymentWithCartLike paymentWithCartLike,
-                                                   final Transaction transaction) {
-        final String transactionId = transaction.getId();
-        final int sequenceNumber = getNextSequenceNumber(paymentWithCartLike);
-
-        final AuthorizationRequest request = requestFactory.createPreauthorizationRequest(paymentWithCartLike);
-
-        final Payment updatedPayment = client.executeBlocking(
-            PaymentUpdateCommand.of(paymentWithCartLike.getPayment(),
-                ImmutableList.of(
-                        AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_REQUEST,
-                            ImmutableMap.of(CustomFieldKeys.REQUEST_FIELD, request.toStringMap(true).toString(),
-                                    CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
-                                    CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now())),
-                        ChangeTransactionInteractionId.of(String.valueOf(sequenceNumber), transactionId))
-            ));
-
-        try {
-            final Map<String, String> response = payonePostService.executePost(request);
-
-            final String status = response.get(STATUS);
-
-            final AddInterfaceInteraction interfaceInteraction = AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE,
-                ImmutableMap.of(CustomFieldKeys.RESPONSE_FIELD, responseToJsonString(response),
-                        CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
-                        CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now()));
-
-            if (ResponseStatus.APPROVED.getStateCode().equals(status)) {
-
-                return update(paymentWithCartLike, updatedPayment, getBankTransferAdvancedUpdateActions(TransactionState.PENDING, updatedPayment, transactionId, response, interfaceInteraction));
-
-            } else if (ResponseStatus.ERROR.getStateCode().equals(status)) {
-
-                return update(paymentWithCartLike, updatedPayment, getDefaultUpdateActions(TransactionState.FAILURE, updatedPayment, transactionId, response, interfaceInteraction));
-
-            } else if (ResponseStatus.PENDING.getStateCode().equals(status)) {
-
-                return update(paymentWithCartLike, updatedPayment, getDefaultSuccessUpdateActions(TransactionState.PENDING, updatedPayment, transactionId, response, interfaceInteraction));
-
-            }
-
-            // TODO: https://github.com/commercetools/commercetools-payone-integration/issues/199
-            throw new IllegalStateException("Unknown PayOne status: " + status);
-        } catch (PayoneException pe) {
-            LOGGER.error("Payone request exception: ", pe);
-
-            final AddInterfaceInteraction interfaceInteraction = AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE,
-                    ImmutableMap.of(CustomFieldKeys.RESPONSE_FIELD, exceptionToResponseJsonString(pe),
-                            CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
-                            CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now()));
-
-            final ChangeTransactionState failureTransaction = ChangeTransactionState.of(TransactionState.FAILURE, transactionId);
-
-            return update(paymentWithCartLike, updatedPayment, ImmutableList.of(interfaceInteraction, failureTransaction));
-        }
+    protected AuthorizationRequest createRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+        return requestFactory.createAuthorizationRequest(paymentWithCartLike);
     }
-
-    /**
-     * Additionally to {@link #getDefaultSuccessUpdateActions(TransactionState, Payment, String, Map, AddInterfaceInteraction)}
-     * adds payer and IBAN/BIC custom fields.
-     * <p>
-     * This update actions list is used for all success payment handling (including redirect, approved and pending)
-     */
-    protected List<UpdateActionImpl<Payment>> getBankTransferAdvancedUpdateActions(@Nonnull TransactionState newState,
-                                                                                   @Nonnull Payment updatedPayment,
-                                                                                   @Nonnull String transactionId,
-                                                                                   @Nonnull Map<String, String> response,
-                                                                                   @Nonnull AddInterfaceInteraction interfaceInteraction) {
-
-        List<UpdateActionImpl<Payment>> updateActions = getDefaultSuccessUpdateActions(newState, updatedPayment, transactionId, response, interfaceInteraction);
-
-        updateActions.add(SetCustomField.ofObject(CustomFieldKeys.PAY_TO_BIC_FIELD, response.get(BIC)));
-        updateActions.add(SetCustomField.ofObject(CustomFieldKeys.PAY_TO_IBAN_FIELD, response.get(IBAN)));
-        updateActions.add(SetCustomField.ofObject(CustomFieldKeys.PAY_TO_NAME_FIELD, response.get(ACCOUNT_HOLDER)));
-
-        return updateActions;
-    }
-
-
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
@@ -1,0 +1,197 @@
+package com.commercetools.pspadapter.payone.transaction.paymentinadvance;
+
+import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
+import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
+import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
+import com.commercetools.pspadapter.payone.domain.payone.exceptions.PayoneException;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus;
+import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
+import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
+import com.commercetools.pspadapter.payone.transaction.TransactionBaseExecutor;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.commands.UpdateActionImpl;
+import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.Transaction;
+import io.sphere.sdk.payments.TransactionState;
+import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
+import io.sphere.sdk.payments.commands.updateactions.AddInterfaceInteraction;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionInteractionId;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
+import io.sphere.sdk.payments.commands.updateactions.SetCustomField;
+import io.sphere.sdk.types.CustomFields;
+import io.sphere.sdk.types.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.time.ZonedDateTime;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.*;
+
+/**
+ * Responsible to create the PayOne Request (PreAuthorization) and check if answer is approved or Error
+ *
+ * @author mht@dotsource.de
+ */
+abstract class BaseBankTransferInAdvanceTransactionExecutor extends TransactionBaseExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseBankTransferInAdvanceTransactionExecutor.class);
+    protected final TransactionType transactionType;
+    protected final PayoneRequestFactory requestFactory;
+    protected final PayonePostService payonePostService;
+
+    protected BaseBankTransferInAdvanceTransactionExecutor(@Nonnull final TransactionType transactionType,
+                                                           @Nonnull final LoadingCache<String, Type> typeCache,
+                                                           @Nonnull final PayoneRequestFactory requestFactory,
+                                                           @Nonnull final PayonePostService payonePostService,
+                                                           @Nonnull final BlockingSphereClient client) {
+        super(typeCache, client);
+        this.transactionType = transactionType;
+        this.requestFactory = requestFactory;
+        this.payonePostService = payonePostService;
+    }
+
+    @Nonnull
+    @Override
+    public TransactionType supportedTransactionType() {
+        return transactionType;
+    }
+
+    /**
+     * Create respective authorization or preauthorization request for
+     * {@link #attemptExecution(PaymentWithCartLike, Transaction)} call.
+     *
+     * @param paymentWithCartLike payment/cart which supply in the request
+     * @return
+     */
+    @Nonnull
+    protected abstract AuthorizationRequest createRequest(@Nonnull PaymentWithCartLike paymentWithCartLike);
+
+    @Override
+    protected boolean wasExecuted(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
+        if (getCustomFieldsOfType(paymentWithCartLike,
+                CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE)
+                .noneMatch(fields -> transaction.getId().equals(fields.getFieldAsString(CustomFieldKeys.TRANSACTION_ID_FIELD)))) {
+
+            return getCustomFieldsOfType(paymentWithCartLike, CustomTypeBuilder.PAYONE_INTERACTION_NOTIFICATION)
+                    //sequenceNumber field is mandatory -> can't be null
+                    .anyMatch(fields -> fields.getFieldAsString(CustomFieldKeys.SEQUENCE_NUMBER_FIELD).equals(transaction.getInteractionId()));
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public Optional<CustomFields> findLastExecutionAttempt(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
+        return getCustomFieldsOfType(paymentWithCartLike, CustomTypeBuilder.PAYONE_INTERACTION_REQUEST)
+                .filter(i -> i.getFieldAsString(CustomFieldKeys.TRANSACTION_ID_FIELD).equals(transaction.getId()))
+                .reduce((previous, current) -> current);
+    }
+
+    @Override
+    @Nonnull
+    public PaymentWithCartLike retryLastExecutionAttempt(@Nonnull PaymentWithCartLike paymentWithCartLike,
+                                                         @Nonnull Transaction transaction,
+                                                         @Nonnull CustomFields lastExecutionAttempt) {
+        if (lastExecutionAttempt.getFieldAsDateTime(CustomFieldKeys.TIMESTAMP_FIELD).isBefore(ZonedDateTime.now().minusMinutes(5))) {
+            return attemptExecution(paymentWithCartLike, transaction);
+        } else {
+            if (lastExecutionAttempt.getFieldAsDateTime(CustomFieldKeys.TIMESTAMP_FIELD).isAfter(ZonedDateTime.now().minusMinutes(1)))
+                throw new ConcurrentModificationException(String.format(
+                        "A processing of payment with ID \"%s\" started during the last 60 seconds and is likely to be finished soon, no need to retry now.",
+                        paymentWithCartLike.getPayment().getId()));
+        }
+        return paymentWithCartLike;
+    }
+
+    @Override
+    @Nonnull
+    protected PaymentWithCartLike attemptExecution(final PaymentWithCartLike paymentWithCartLike,
+                                                   final Transaction transaction) {
+        final String transactionId = transaction.getId();
+        final int sequenceNumber = getNextSequenceNumber(paymentWithCartLike);
+
+        final AuthorizationRequest request = createRequest(paymentWithCartLike);
+
+        final Payment updatedPayment = client.executeBlocking(
+                PaymentUpdateCommand.of(paymentWithCartLike.getPayment(),
+                        ImmutableList.of(
+                                AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_REQUEST,
+                                        ImmutableMap.of(CustomFieldKeys.REQUEST_FIELD, request.toStringMap(true).toString(),
+                                                CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
+                                                CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now())),
+                                ChangeTransactionInteractionId.of(String.valueOf(sequenceNumber), transactionId))
+                ));
+
+        try {
+            final Map<String, String> response = payonePostService.executePost(request);
+
+            final String status = response.get(STATUS);
+
+            final AddInterfaceInteraction interfaceInteraction = AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE,
+                    ImmutableMap.of(CustomFieldKeys.RESPONSE_FIELD, responseToJsonString(response),
+                            CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
+                            CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now()));
+
+            if (ResponseStatus.APPROVED.getStateCode().equals(status)) {
+
+                return update(paymentWithCartLike, updatedPayment, getBankTransferAdvancedUpdateActions(TransactionState.PENDING, updatedPayment, transactionId, response, interfaceInteraction));
+
+            } else if (ResponseStatus.ERROR.getStateCode().equals(status)) {
+
+                return update(paymentWithCartLike, updatedPayment, getDefaultUpdateActions(TransactionState.FAILURE, updatedPayment, transactionId, response, interfaceInteraction));
+
+            } else if (ResponseStatus.PENDING.getStateCode().equals(status)) {
+
+                return update(paymentWithCartLike, updatedPayment, getDefaultSuccessUpdateActions(TransactionState.PENDING, updatedPayment, transactionId, response, interfaceInteraction));
+
+            }
+
+            // TODO: https://github.com/commercetools/commercetools-payone-integration/issues/199
+            throw new IllegalStateException("Unknown PayOne status: " + status);
+        } catch (PayoneException pe) {
+            LOGGER.error("Payone request exception: ", pe);
+
+            final AddInterfaceInteraction interfaceInteraction = AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE,
+                    ImmutableMap.of(CustomFieldKeys.RESPONSE_FIELD, exceptionToResponseJsonString(pe),
+                            CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
+                            CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now()));
+
+            final ChangeTransactionState failureTransaction = ChangeTransactionState.of(TransactionState.FAILURE, transactionId);
+
+            return update(paymentWithCartLike, updatedPayment, ImmutableList.of(interfaceInteraction, failureTransaction));
+        }
+    }
+
+    /**
+     * Additionally to {@link #getDefaultSuccessUpdateActions(TransactionState, Payment, String, Map, AddInterfaceInteraction)}
+     * adds payer and IBAN/BIC custom fields.
+     * <p>
+     * This update actions list is used for all success payment handling (including redirect, approved and pending)
+     */
+    protected List<UpdateActionImpl<Payment>> getBankTransferAdvancedUpdateActions(@Nonnull TransactionState newState,
+                                                                                   @Nonnull Payment updatedPayment,
+                                                                                   @Nonnull String transactionId,
+                                                                                   @Nonnull Map<String, String> response,
+                                                                                   @Nonnull AddInterfaceInteraction interfaceInteraction) {
+
+        List<UpdateActionImpl<Payment>> updateActions = getDefaultSuccessUpdateActions(newState, updatedPayment, transactionId, response, interfaceInteraction);
+
+        updateActions.add(SetCustomField.ofObject(CustomFieldKeys.PAY_TO_BIC_FIELD, response.get(BIC)));
+        updateActions.add(SetCustomField.ofObject(CustomFieldKeys.PAY_TO_IBAN_FIELD, response.get(IBAN)));
+        updateActions.add(SetCustomField.ofObject(CustomFieldKeys.PAY_TO_NAME_FIELD, response.get(ACCOUNT_HOLDER)));
+
+        return updateActions;
+    }
+
+
+}

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -242,8 +242,8 @@ public class TenantFactory {
                 return new AuthorizationTransactionExecutor(typeCache, requestFactory, postService, client);
             case CHARGE:
                 switch (paymentMethod) {
-//                    case BANK_TRANSFER_ADVANCE:
-//                        return new BankTransferInAdvanceChargeTransactionExecutor(typeCache, requestFactory, postService, client);
+                    case BANK_TRANSFER_ADVANCE:
+                        return new BankTransferInAdvanceChargeTransactionExecutor(typeCache, requestFactory, postService, client);
                     default:
                         return new ChargeTransactionExecutor(typeCache, requestFactory, postService, client);
                 }

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -24,6 +24,7 @@ import com.commercetools.pspadapter.payone.transaction.TransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.common.AuthorizationTransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.common.ChargeTransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.common.UnsupportedTransactionExecutor;
+import com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceAuthorizationTransactionExecutor;
 import com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceChargeTransactionExecutor;
 import com.commercetools.service.OrderService;
 import com.commercetools.service.OrderServiceImpl;
@@ -239,7 +240,12 @@ public class TenantFactory {
 
         switch (transactionType) {
             case AUTHORIZATION:
-                return new AuthorizationTransactionExecutor(typeCache, requestFactory, postService, client);
+                switch (paymentMethod) {
+                    case BANK_TRANSFER_ADVANCE:
+                        return new BankTransferInAdvanceAuthorizationTransactionExecutor(typeCache, requestFactory, postService, client);
+                    default:
+                        return new AuthorizationTransactionExecutor(typeCache, requestFactory, postService, client);
+                }
             case CHARGE:
                 switch (paymentMethod) {
                     case BANK_TRANSFER_ADVANCE:

--- a/service/src/main/java/com/commercetools/util/function/TriFunction.java
+++ b/service/src/main/java/com/commercetools/util/function/TriFunction.java
@@ -1,0 +1,21 @@
+package com.commercetools.util.function;
+
+import java.util.function.Function;
+
+/**
+ * Similar to {@link java.util.function.BiFunction}:
+ * <p>
+ * Represents a function that accepts tree arguments and produces a result.
+ * This is the tree-arity specialization of {@link Function}.
+ * <p>
+ * This is a functional interface whose functional method is {@link #apply(Object, Object, Object)}.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <V> the type of the third argument to the function
+ * @param <R> the type of the result of the function
+ */
+@FunctionalInterface
+public interface TriFunction<T, U, V, R> {
+    R apply(T t, U u, V v);
+}

--- a/service/src/test/java/com/commercetools/pspadapter/payone/PaymentDispatcherTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/PaymentDispatcherTest.java
@@ -88,11 +88,11 @@ public class PaymentDispatcherTest {
         final Transaction firstInitTransaction = paymentPendingOrInitial.getTransactions().get(0);
 
         final CountingPaymentMethodDispatcher creditCardDispatcher = new CountingPaymentMethodDispatcher();
-        final CountingPaymentMethodDispatcher sepaDispatcher = new CountingPaymentMethodDispatcher();
+        final CountingPaymentMethodDispatcher postFinanceDispatcher = new CountingPaymentMethodDispatcher();
 
         final HashMap<PaymentMethod, PaymentMethodDispatcher> methodDispatcherMap = new HashMap<>();
         methodDispatcherMap.put(PaymentMethod.CREDIT_CARD, creditCardDispatcher);
-        methodDispatcherMap.put(PaymentMethod.DIRECT_DEBIT_SEPA, sepaDispatcher);
+        methodDispatcherMap.put(PaymentMethod.BANK_TRANSFER_POSTFINANCE_EFINANCE, postFinanceDispatcher);
 
         PaymentDispatcher dispatcher = new PaymentDispatcher(methodDispatcherMap, PAYONE);
         dispatcher.dispatchPayment(paymentPendingOrInitialWithCartLike);
@@ -105,7 +105,7 @@ public class PaymentDispatcherTest {
         // credit card is dispatched ones, cos it has only one CC payment
         assertThat(creditCardDispatcher.count).isEqualTo(1);
         // sepa is not called, because there were no sepa payments
-        assertThat(sepaDispatcher.count).isEqualTo(0);
+        assertThat(postFinanceDispatcher.count).isEqualTo(0);
 
         // PaymentMethodDispatcher#dispatchPayment() filters in first in-completed (Initial/Pending) transaction,
         // and then verifies updated transaction, which is the same in our case.
@@ -121,6 +121,6 @@ public class PaymentDispatcherTest {
         // second (accumulated) with test above CC dispatch call
         assertThat(creditCardDispatcher.count).isEqualTo(1 + 1);
         // sepa still never called
-        assertThat(sepaDispatcher.count).isEqualTo(0);
+        assertThat(postFinanceDispatcher.count).isEqualTo(0);
     }
 }

--- a/service/src/test/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethodTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/domain/ctp/paymentmethods/PaymentMethodTest.java
@@ -10,8 +10,8 @@ import org.junit.Test;
  */
 public class PaymentMethodTest {
     @Test
-    public void getsDirectDebitSepaPaymentMethodFromMethodKey() {
-        assertThat(PaymentMethod.fromMethodKey(MethodKeys.DIRECT_DEBIT_SEPA)).isSameAs(PaymentMethod.DIRECT_DEBIT_SEPA);
+    public void getsPostfinanceEfinancePaymentMethodFromMethodKey() {
+        assertThat(PaymentMethod.fromMethodKey(MethodKeys.BANK_TRANSFER_POSTFINANCE_EFINANCE)).isSameAs(PaymentMethod.BANK_TRANSFER_POSTFINANCE_EFINANCE);
     }
 
     @Test

--- a/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferRequestTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferRequestTest.java
@@ -1,10 +1,5 @@
 package com.commercetools.pspadapter.payone.domain.payone.model.banktransfer;
 
-import static com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType.PAYONE_PNT;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.MapEntry.entry;
-import static org.mockito.Mockito.when;
-
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
 import org.junit.Before;
@@ -13,12 +8,18 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType.PAYONE_PNT;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType.AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.mockito.Mockito.when;
+
 /**
  * @author fhaertig
  * @since 19.04.16
  */
 @RunWith(MockitoJUnitRunner.class)
-public class BankTransferAuthorizationRequestTest {
+public class BankTransferRequestTest {
     private static final String onlinebanktransfertype = "test-type";
     private static final String merchantId = "merchant X";
     private static final String portalId = "portal 23";
@@ -43,7 +44,7 @@ public class BankTransferAuthorizationRequestTest {
     @Test
     public void createsFullMap() {
         //create with required properties
-        final BankTransferAuthorizationRequest request = new BankTransferAuthorizationRequest(payoneConfig, onlinebanktransfertype);
+        final BankTransferRequest request = new BankTransferRequest(AUTHORIZATION, payoneConfig, onlinebanktransfertype);
         request.setIban(iban);
         request.setBic(bic);
 
@@ -64,7 +65,7 @@ public class BankTransferAuthorizationRequestTest {
     @Test
     public void createsMapWithHiddenSecrets() {
         //create with required properties
-        final BankTransferAuthorizationRequest request = new BankTransferAuthorizationRequest(payoneConfig, onlinebanktransfertype);
+        final BankTransferRequest request = new BankTransferRequest(AUTHORIZATION, payoneConfig, onlinebanktransfertype);
         request.setIban(iban);
         request.setBic(bic);
 

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
@@ -4,7 +4,7 @@ import com.commercetools.pspadapter.BaseTenantPropertyTest;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
-import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvancePreautorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvanceRequest;
 import com.commercetools.pspadapter.tenant.TenantPropertyProvider;
 import io.sphere.sdk.models.Address;
 import io.sphere.sdk.orders.Order;
@@ -54,7 +54,7 @@ public class BankTransferInAdvanceRequestFactoryTest extends BaseTenantPropertyT
         Order order = payments.dummyOrderMapToPayoneRequest();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferInAdvancePreautorizationRequest result = factory.createPreauthorizationRequest(paymentWithCartLike);
+        BankTransferInAdvanceRequest result = factory.createPreauthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceCardRequestFactoryTest.java
@@ -2,7 +2,7 @@ package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.BaseTenantPropertyTest;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import io.sphere.sdk.customers.Customer;
@@ -52,7 +52,7 @@ public class PostfinanceCardRequestFactoryTest extends BaseTenantPropertyTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/PostfinanceEfinanceRequestFactoryTest.java
@@ -2,7 +2,7 @@ package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.BaseTenantPropertyTest;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import io.sphere.sdk.customers.Customer;
@@ -50,7 +50,7 @@ public class PostfinanceEfinanceRequestFactoryTest extends BaseTenantPropertyTes
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortRequestFactoryTest.java
@@ -3,7 +3,7 @@ package com.commercetools.pspadapter.payone.mapping;
 import com.commercetools.pspadapter.BaseTenantPropertyTest;
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import com.commercetools.pspadapter.tenant.TenantConfig;
@@ -56,7 +56,7 @@ public class SofortRequestFactoryTest extends BaseTenantPropertyTest {
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values
@@ -145,7 +145,7 @@ public class SofortRequestFactoryTest extends BaseTenantPropertyTest {
         Order order = payments.dummyOrderMapToPayoneRequest();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithIbanRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithIbanRequestFactoryTest.java
@@ -2,7 +2,7 @@ package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.BaseTenantPropertyTest;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferRequest;
 import io.sphere.sdk.orders.Order;
 import io.sphere.sdk.payments.Payment;
 import org.junit.Before;
@@ -29,7 +29,7 @@ public class SofortWithIbanRequestFactoryTest extends BaseTenantPropertyTest {
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
 
         SofortBankTransferRequestFactory factory = new SofortBankTransferRequestFactory(tenantConfig);
-        BankTransferAuthorizationRequest authorizationRequest = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest authorizationRequest = factory.createAuthorizationRequest(paymentWithCartLike);
 
         assertThat(authorizationRequest.getIban()).isEqualTo("DE66778899");
         assertThat(authorizationRequest.getBic()).isEqualTo("BIC_TEST_TEST");
@@ -45,7 +45,7 @@ public class SofortWithIbanRequestFactoryTest extends BaseTenantPropertyTest {
         when(tenantConfig.getSecureKey()).thenReturn("qwertyuiopasdfgh");
 
         SofortBankTransferRequestFactory factory = new SofortBankTransferRequestFactory(tenantConfig);
-        BankTransferAuthorizationRequest authorizationRequest = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest authorizationRequest = factory.createAuthorizationRequest(paymentWithCartLike);
 
         assertThat(authorizationRequest.getIban()).isEqualTo("DE66778899");
         assertThat(authorizationRequest.getBic()).isEqualTo("BIC_TEST_TEST");

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/SofortWithoutIbanRequestFactoryTest.java
@@ -3,7 +3,7 @@ package com.commercetools.pspadapter.payone.mapping;
 import com.commercetools.pspadapter.BaseTenantPropertyTest;
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
-import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferAuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.banktransfer.BankTransferRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ClearingType;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import com.commercetools.pspadapter.tenant.TenantConfig;
@@ -57,7 +57,7 @@ public class SofortWithoutIbanRequestFactoryTest extends BaseTenantPropertyTest 
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values
@@ -144,7 +144,7 @@ public class SofortWithoutIbanRequestFactoryTest extends BaseTenantPropertyTest 
         Customer customer = payment.getCustomer().getObj();
 
         PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, order);
-        BankTransferAuthorizationRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
+        BankTransferRequest result = factory.createAuthorizationRequest(paymentWithCartLike);
         SoftAssertions softly = new SoftAssertions();
 
         //base values

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
@@ -1,7 +1,7 @@
 package com.commercetools.pspadapter.payone.transaction.paymentinadvance;
 
 import com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields;
-import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvancePreautorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.BankTransferInAdvanceRequest;
 import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
 import com.commercetools.pspadapter.payone.transaction.BaseTransaction_attemptExecutionTest;
 import com.google.common.collect.ImmutableMap;
@@ -28,7 +28,7 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
     private BankTransferInAdvanceChargeTransactionExecutor executor;
 
     @Mock
-    protected BankTransferInAdvancePreautorizationRequest preAuthorizationRequest;
+    protected BankTransferInAdvanceRequest preAuthorizationRequest;
 
 
     @Override

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
@@ -25,10 +25,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends BaseTransaction_attemptExecutionTest {
 
-    private BankTransferInAdvanceChargeTransactionExecutor executor;
+    private BaseBankTransferInAdvanceTransactionExecutor executor;
 
     @Mock
-    protected BankTransferInAdvanceRequest preAuthorizationRequest;
+    protected BankTransferInAdvanceRequest bankTransferInAdvanceRequest;
 
 
     @Override
@@ -37,14 +37,15 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
         super.setUp();
         executor = new BankTransferInAdvanceChargeTransactionExecutor(typeCache, requestFactory, payonePostService, client);
 
-        when(preAuthorizationRequest.toStringMap(anyBoolean())).thenReturn(ImmutableMap.of("testRequestKey1", "testRequestValue2",
+        when(bankTransferInAdvanceRequest.toStringMap(anyBoolean())).thenReturn(ImmutableMap.of("testRequestKey1", "testRequestValue2",
                 "testRequestKey2", "testRequestValue2"));
-        when(requestFactory.createPreauthorizationRequest(paymentWithCartLike)).thenReturn(preAuthorizationRequest);
+        when(requestFactory.createPreauthorizationRequest(paymentWithCartLike)).thenReturn(bankTransferInAdvanceRequest);
+        when(requestFactory.createAuthorizationRequest(paymentWithCartLike)).thenReturn(bankTransferInAdvanceRequest);
     }
 
     @Test
     public void attemptExecution_withApprovedResponse_createsUpdateActions() throws Exception {
-        when(payonePostService.executePost(preAuthorizationRequest)).thenReturn(ImmutableMap.of(
+        when(payonePostService.executePost(bankTransferInAdvanceRequest)).thenReturn(ImmutableMap.of(
                 PayoneResponseFields.STATUS, APPROVED.getStateCode(),
                 PayoneResponseFields.TXID, "responseTxid",
 
@@ -73,22 +74,22 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
 
     @Test
     public void attemptExecution_withErrorResponse_createsUpdateActions() throws Exception {
-        super.attemptExecution_withErrorResponse_createsUpdateActions(preAuthorizationRequest, executor);
+        super.attemptExecution_withErrorResponse_createsUpdateActions(bankTransferInAdvanceRequest, executor);
     }
 
     @Test
     public void attemptExecution_withPendingResponse_createsUpdateActions() throws Exception {
-        super.attemptExecution_withPendingResponse_createsUpdateActions(preAuthorizationRequest, executor);
+        super.attemptExecution_withPendingResponse_createsUpdateActions(bankTransferInAdvanceRequest, executor);
     }
 
     @Test
     public void attemptExecution_withPayoneException_createsUpdateActions() throws Exception {
-        super.attemptExecution_withPayoneException_createsUpdateActions(preAuthorizationRequest, executor);
+        super.attemptExecution_withPayoneException_createsUpdateActions(bankTransferInAdvanceRequest, executor);
     }
 
     @Test
     public void attemptExecution_withUnexpectedResponseStatus_throwsException() throws Exception {
-        super.attemptExecution_withUnexpectedResponseStatus_throwsException(preAuthorizationRequest, executor);
+        super.attemptExecution_withUnexpectedResponseStatus_throwsException(bankTransferInAdvanceRequest, executor);
     }
 
     /**
@@ -98,7 +99,7 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
      */
     @Test
     public void attemptExecution_withRedirectResponse_throwsException() throws Exception {
-        when(payonePostService.executePost(preAuthorizationRequest)).thenReturn(ImmutableMap.of(
+        when(payonePostService.executePost(bankTransferInAdvanceRequest)).thenReturn(ImmutableMap.of(
                 PayoneResponseFields.STATUS, REDIRECT.getStateCode(),
                 PayoneResponseFields.REDIRECT_URL, "http://mock-redirect.url",
                 PayoneResponseFields.TXID, "responseTxid"

--- a/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
@@ -6,28 +6,51 @@ import com.commercetools.pspadapter.payone.PaymentDispatcher;
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
+import com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod;
+import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
+import com.commercetools.pspadapter.payone.domain.payone.exceptions.PayoneException;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.BaseRequest;
+import com.commercetools.pspadapter.payone.domain.payone.model.common.RequestType;
 import com.commercetools.pspadapter.payone.domain.payone.model.klarna.KlarnaAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.klarna.KlarnaPreauthorizationRequest;
 import com.commercetools.pspadapter.payone.mapping.CountryToLanguageMapper;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.client.SphereClientConfig;
+import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import io.sphere.sdk.payments.Transaction;
+import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
+import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import util.PaymentTestHelper;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 
-import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.INVOICE_KLARNA;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.*;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.STATUS;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus.APPROVED;
+import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.REFERENCE_FIELD;
+import static io.sphere.sdk.payments.TransactionState.INITIAL;
+import static io.sphere.sdk.payments.TransactionType.AUTHORIZATION;
+import static io.sphere.sdk.payments.TransactionType.CHARGE;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TenantFactoryTest {
@@ -131,14 +154,121 @@ public class TenantFactoryTest {
         LoadingCache<String, Type> typeCache = mock(LoadingCache.class);
         BlockingSphereClient blockingSphereClient = mock(BlockingSphereClient.class);
 
-        PaymentDispatcher paymentDispatcher = factory.createPaymentDispatcher(tenantConfig, typeCache,
-                blockingSphereClient, transactionStateResolver);
+        PaymentDispatcher paymentDispatcher = factory.createPaymentDispatcher(tenantConfig, typeCache, blockingSphereClient,
+                mock(PayonePostService.class), transactionStateResolver);
         assertThat(paymentDispatcher).isNotNull();
+    }
+
+    /**
+     * Verify all values from cartesian product of {@link PaymentMethod#supportedTransactionTypes} and
+     * {@link PaymentMethod#supportedTransactionTypes} are processed by the service payment dispatcher,
+     * e.g. proper request type is sent to Payone.
+     */
+    @Test
+    public void createdMethodDispatcher_handlesAuthorizationAndCharge_forAllPaymentMethods() throws PayoneException {
+
+        assertThat(supportedTransactionTypes).contains(AUTHORIZATION, CHARGE);
+        assertThat(supportedPaymentMethods.size()).isGreaterThan(0); // at least one method is supported, isn't it?
+
+        // 1. Iterate all supported payment methods
+        for (PaymentMethod supportedPaymentMethod : supportedPaymentMethods) {
+            // 2. Iterate all expected transaction types
+            for (TransactionType supportedTransactionType : supportedTransactionTypes) {
+
+                // 3. mock payment with required custom fields and transaction with specific AUTHORIZATION or CHARGE type
+                Payment payment = mock(Payment.class);
+                when(payment.getPaymentMethodInfo()).thenReturn(PaymentMethodInfoBuilder.of()
+                        .paymentInterface("testPayoneInterfaceName")
+                        .method(supportedPaymentMethod.getKey())
+                        .build());
+
+                CustomFields customFields = mock(CustomFields.class);
+                when(payment.getCustom()).thenReturn(customFields);
+                when(customFields.getFieldAsString(REFERENCE_FIELD)).thenReturn("test-createdMethodDispatcher");
+
+                Transaction transaction = mock(Transaction.class);
+                when(payment.getTransactions()).thenReturn(singletonList(transaction));
+                when(transaction.getState()).thenReturn(INITIAL);
+
+                when(transaction.getId()).thenReturn("test-transaction-uuid");
+                when(transaction.getType()).thenReturn(supportedTransactionType); //AUTHORIZATION and CHARGE
+
+                PaymentWithCartLike pwcl = testHelper.createDummyPaymentWithCartLike(payment, mock(Cart.class));
+
+                // 4. mock sphere client and payone post service to return success
+                BlockingSphereClient client = mock(BlockingSphereClient.class);
+                when(client.executeBlocking(any(PaymentUpdateCommand.class))).thenReturn(payment);
+                PayonePostService payonePostService = mock(PayonePostService.class);
+                when(payonePostService.executePost(any(BaseRequest.class))).thenReturn(ImmutableMap.of(STATUS, APPROVED.getStateCode()));
+
+                // 5. inject mocked CTP and Payone services to tenant factory
+                TenantFactory factory = mockTenantFactory(tenantConfig, client, payonePostService);
+
+                // 6. Make actual call. No exception should be thrown
+                factory.getPaymentDispatcher().dispatchPayment(pwcl);
+
+                // 7. Capture sent values and verify they have expected
+                // "preauthorization" or "authorization" Payone request type
+                ArgumentCaptor<BaseRequest> payoneRequestCaptor = ArgumentCaptor.forClass(BaseRequest.class);
+                verify(payonePostService, times(1)).executePost(payoneRequestCaptor.capture());
+                assertThat(payoneRequestCaptor.getValue()).isInstanceOf(AuthorizationRequest.class);
+                AuthorizationRequest request = (AuthorizationRequest) payoneRequestCaptor.getValue();
+                String expectedPayoneRequestType = mapCtpTransactionToPayoneRequestType(supportedTransactionType);
+                String actualPayoneRequestType = request.getRequest();
+                assertThat(actualPayoneRequestType)
+                        .withFailMessage(format("Unexpected Payone request type for respective CTP transaction [%s] in payment type [%s].\n\tExpected: [%s]\n\tActual: [%s]",
+                                supportedTransactionType.toSphereName(), supportedPaymentMethod.getKey(), expectedPayoneRequestType, actualPayoneRequestType))
+                        .isEqualTo(expectedPayoneRequestType);
+            }
+        }
     }
 
     @Test
     public void createCountryToLanguageMapper() throws Exception {
         CountryToLanguageMapper paymentDispatcher = factory.createCountryToLanguageMapper();
         assertThat(paymentDispatcher).isNotNull();
+    }
+
+    /**
+     * Because {@link TenantFactory} initializes {@link com.commercetools.pspadapter.payone.PaymentHandler}
+     * and {@link PaymentDispatcher} inside constructor, we can't easily mock an instance, thus we make this anonymous
+     * class extending.
+     *
+     * @param tenantConfig         {@link TenantConfig} to inject
+     * @param blockingSphereClient {@link BlockingSphereClient} to inject
+     * @param payonePostService    {@link PayonePostService} to inject
+     * @return instance of {@link TenantFactory} with injected values from above.
+     */
+    private static TenantFactory mockTenantFactory(TenantConfig tenantConfig, BlockingSphereClient blockingSphereClient, PayonePostService payonePostService) {
+        return new TenantFactory("testPayoneInterfaceName", tenantConfig) {
+            @Nonnull
+            @Override
+            protected BlockingSphereClient createBlockingSphereClient(TenantConfig tenantConfig) {
+                return blockingSphereClient;
+            }
+
+            @Nonnull
+            @Override
+            protected PayonePostService getPayonePostService(TenantConfig tenantConfig) {
+                return payonePostService;
+            }
+        };
+    }
+
+    /**
+     * <table border="1">
+     * <tr><th>CTP</th><td>&nbsp;</td><th>Payone</th></tr>
+     * <tr><td>{@link TransactionType#AUTHORIZATION}</td><td>&nbsp;-&gt;&nbsp;</td><td>{@link RequestType#PREAUTHORIZATION}</td></tr>
+     * <tr><td>{@link TransactionType#CHARGE}</td><td>&nbsp;-&gt;&nbsp;</td><td>{@link RequestType#AUTHORIZATION}</td></tr>
+     * <tr><td>other</td><td>&nbsp;-&gt;&nbsp;</td><td>"unexpected transaction request type "%s""</td></tr>
+     * </table>
+     *
+     * @param ctpTransactionType CTP {@link TransactionType} to map to respective Payone request type
+     * @return mapped string value like in the table above.
+     */
+    private static String mapCtpTransactionToPayoneRequestType(TransactionType ctpTransactionType) {
+        return ctpTransactionType == AUTHORIZATION ? RequestType.PREAUTHORIZATION.getType() :
+                (ctpTransactionType == CHARGE ? RequestType.AUTHORIZATION.getType() :
+                        format("unexpected transaction request type \"%s\"", ctpTransactionType));
     }
 }


### PR DESCRIPTION
as a hot fix for https://github.com/commercetools/commercetools-payone-integration/issues/217:

Now we don't validate transaction type: the customer should create proper transaction type on theirs own, the service simply executes transaction on payone, if it is possible.

- [`PaymentMethods`](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-3439e6d93c20fc6f9d51971b99d0cd1e)
  - removed `AUTHORIZATION`/`CHARGE` limits for every payment method
  - define global `supportedTransactionTypes` set of supported types

- [`BankTransferAuthorizationRequest/BankTransferRequest `](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-c0d8899cbde8d8d068967980a34c0a3c): make it flexible, accepting request type as a constructor arguments.
Same for [`BankTransferInAdvancePreautorizationRequest/BankTransferInAdvanceRequest`](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-b7b6c7037201d91d340ee35ee1a0e8d5)

- [`SofortBankTransferRequestFactory `](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-cc21a529ce437cdf3420cbcdf4e7322e): using default basic `super.createPreauthorizationRequest/super.createAuthorizationRequest` just patch them additionally with IBAN/BIC fields where it is necessary.

- [`TenantFactory`](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-d34fd6b71077118ff85d598f7827ba76): 
  - because of bad design from the beginning and instantiation values inside constructor (instead of DI), we have to re-factor this class slowly from PR to PR. This time we make `PayonePostService` mocking/injection possible. See also [`tenantFactoryTest`](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-933c751c42680c69e2d881da80d71627R242) for more details.
  - [remove duplication+hardcoding of supported payment methods](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-d34fd6b71077118ff85d598f7827ba76L208), use `supportedPaymentMethods` and `supportedTransactionTypes` static sets instead

- added [Unit test](https://github.com/commercetools/commercetools-payone-integration/pull/218/files#diff-933c751c42680c69e2d881da80d71627R168) which verifies all the payment methods could process all the expected CTP transaction types (`AUTHORIZATION` and `CHARGE`)

- Some `@Nonnull` annotation added, classes renamed to reflect better current workflow