### PR TITLE
update warning in case of CHARGE(autorization) transaction for Prepayment (Vorkasse, BankTransferAdvanced) methods

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
@@ -37,7 +37,7 @@ public class BankTransferInAdvanceRequestFactory extends PayoneRequestFactory {
     }
 
     /**
-     * <b>NOTE:</b> this is potentially dangerous transaction type for this payment method. See more in
+     * <b>NOTE:</b> this is a potentially dangerous transaction type for this payment method. See more in
      * {@link com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceChargeTransactionExecutor BankTransferInAdvanceChargeTransactionExecutor}
      * @see com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceChargeTransactionExecutor
      */
@@ -45,7 +45,7 @@ public class BankTransferInAdvanceRequestFactory extends PayoneRequestFactory {
     @Override
     public BankTransferInAdvanceRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
         LOG.warn("Unsupported transaction type \"{}\" for payment method \"\".\n" +
-                        "\t\tNote: this payment/transaction type officially not supported by Payone " +
+                        "\t\tNote: this payment/transaction type officially isn't supported by Payone " +
                         "and thus the behavior of such transaction handling is undefined.\n" +
                         "Either change the created transaction type or update the service if the Payone API has changed.",
                 RequestType.AUTHORIZATION, BANK_TRANSFER_ADVANCE.getKey());

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
@@ -44,7 +44,7 @@ public class BankTransferInAdvanceRequestFactory extends PayoneRequestFactory {
     @Nonnull
     @Override
     public BankTransferInAdvanceRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
-        LOG.warn("Unsupported transaction type \"{}\" for payment method \"\".\n" +
+        LOG.warn("Unsupported transaction type \"{}\" for payment method \"{}\".\n" +
                         "\t\tNote: this payment/transaction type officially isn't supported by Payone " +
                         "and thus the behavior of such transaction handling is undefined.\n" +
                         "Either change the transaction type or update the service if the Payone API has changed.",

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
@@ -47,7 +47,7 @@ public class BankTransferInAdvanceRequestFactory extends PayoneRequestFactory {
         LOG.warn("Unsupported transaction type \"{}\" for payment method \"\".\n" +
                         "\t\tNote: this payment/transaction type officially isn't supported by Payone " +
                         "and thus the behavior of such transaction handling is undefined.\n" +
-                        "Either change the created transaction type or update the service if the Payone API has changed.",
+                        "Either change the transaction type or update the service if the Payone API has changed.",
                 RequestType.AUTHORIZATION, BANK_TRANSFER_ADVANCE.getKey());
         return createRequestInternal(RequestType.AUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
     }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactory.java
@@ -9,19 +9,24 @@ import com.commercetools.pspadapter.payone.domain.payone.model.paymentinadvance.
 import com.commercetools.pspadapter.tenant.TenantConfig;
 import com.google.common.base.Preconditions;
 import io.sphere.sdk.payments.Payment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.BANK_TRANSFER_ADVANCE;
 import static org.javamoney.moneta.function.MonetaryQueries.convertMinorPart;
 
 /**
  * @author mht@dotsource.de
  */
-public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
+public class BankTransferInAdvanceRequestFactory extends PayoneRequestFactory {
 
-    public BanktTransferInAdvanceRequestFactory(@Nonnull final TenantConfig tenantConfig) {
+    private Logger LOG = LoggerFactory.getLogger(BankTransferInAdvanceRequestFactory.class);
+
+    public BankTransferInAdvanceRequestFactory(@Nonnull final TenantConfig tenantConfig) {
         super(tenantConfig);
     }
 
@@ -31,9 +36,19 @@ public class BanktTransferInAdvanceRequestFactory extends PayoneRequestFactory {
         return createRequestInternal(RequestType.PREAUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
     }
 
+    /**
+     * <b>NOTE:</b> this is potentially dangerous transaction type for this payment method. See more in
+     * {@link com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceChargeTransactionExecutor BankTransferInAdvanceChargeTransactionExecutor}
+     * @see com.commercetools.pspadapter.payone.transaction.paymentinadvance.BankTransferInAdvanceChargeTransactionExecutor
+     */
     @Nonnull
     @Override
     public BankTransferInAdvanceRequest createAuthorizationRequest(@Nonnull PaymentWithCartLike paymentWithCartLike) {
+        LOG.warn("Unsupported transaction type \"{}\" for payment method \"\".\n" +
+                        "\t\tNote: this payment/transaction type officially not supported by Payone " +
+                        "and thus the behavior of such transaction handling is undefined.\n" +
+                        "Either change the created transaction type or update the service if the Payone API has changed.",
+                RequestType.AUTHORIZATION, BANK_TRANSFER_ADVANCE.getKey());
         return createRequestInternal(RequestType.AUTHORIZATION, paymentWithCartLike, BankTransferInAdvanceRequest::new);
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
@@ -21,7 +21,7 @@ import static io.sphere.sdk.payments.TransactionType.CHARGE;
  *     Prepayment   Not supported by this request!
  * </pre>
  * <p>
- * Looks like it is accepted by Payone service, but might be switch off in the future any time, also some logistic
+ * Looks like it is accepted by Payone service, but might be switched off in the future any time, also some logistic
  * companies might have issues handling these transaction types for this method
  * (see <a href="https://jira.commercetools.com/browse/CAR-2189">payment request for "Vorkasse" orders has wrong request type</a>)
  */

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
@@ -22,8 +22,7 @@ import static io.sphere.sdk.payments.TransactionType.CHARGE;
  * </pre>
  * <p>
  * Looks like it is accepted by Payone service, but might be switched off in the future any time, also some logistic
- * companies might have issues handling these transaction types for this method
- * (see <a href="https://jira.commercetools.com/browse/CAR-2189">payment request for "Vorkasse" orders has wrong request type</a>)
+ * companies might have issues handling these transaction types for this method.
  */
 public class BankTransferInAdvanceChargeTransactionExecutor extends BaseBankTransferInAdvanceTransactionExecutor {
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
@@ -12,6 +12,19 @@ import javax.annotation.Nonnull;
 
 import static io.sphere.sdk.payments.TransactionType.CHARGE;
 
+/**
+ * <b>Note:</b>: according to <i>TECHNICAL REFERENCE PAYONE Platform Channel Server API v2.92</i>
+ * (chapter <i>3.2.2 Initiating payment process (authorization)</i>)
+ * and <i>Sequenzdiagramme20170130</i> (chapter <i>Retailer – Zahlart Vorkasse mit Vorautorisierung</i>)
+ * this transaction type (Payone <i>authorization</i>) is <b>not</b> supported for this payment method:
+ * <pre>
+ *     Prepayment   Not supported by this request!
+ * </pre>
+ * <p>
+ * Looks like it is accepted by Payone service, but might be switch off in the future any time, also some logistic
+ * companies might have issues handling these transaction types for this method
+ * (see <a href="https://jira.commercetools.com/browse/CAR-2189">payment request for "Vorkasse" orders has wrong request type</a>)
+ */
 public class BankTransferInAdvanceChargeTransactionExecutor extends BaseBankTransferInAdvanceTransactionExecutor {
 
     public BankTransferInAdvanceChargeTransactionExecutor(@Nonnull LoadingCache<String, Type> typeCache,

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
@@ -21,8 +21,7 @@ import static io.sphere.sdk.payments.TransactionType.CHARGE;
  *     Prepayment   Not supported by this request!
  * </pre>
  * <p>
- * Looks like it is accepted by Payone service, but might be switched off in the future any time, also some logistic
- * companies might have issues handling these transaction types for this method.
+ * Looks like it is accepted by Payone service, but might be switched off in the future any time.
  */
 public class BankTransferInAdvanceChargeTransactionExecutor extends BaseBankTransferInAdvanceTransactionExecutor {
 

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -277,7 +277,7 @@ public class TenantFactory {
             case BANK_TRANSFER_POSTFINANCE_EFINANCE:
                 return new PostFinanceBanktransferRequestFactory(tenantConfig);
             case BANK_TRANSFER_ADVANCE:
-                return new BanktTransferInAdvanceRequestFactory(tenantConfig);
+                return new BankTransferInAdvanceRequestFactory(tenantConfig);
             case INVOICE_KLARNA:
                 return new KlarnaRequestFactory(tenantConfig, createCountryToLanguageMapper());
             default:

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BankTransferInAdvanceRequestFactoryTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 public class BankTransferInAdvanceRequestFactoryTest extends BaseTenantPropertyTest {
 
     private final PaymentTestHelper payments = new PaymentTestHelper();
-    private BanktTransferInAdvanceRequestFactory factory;
+    private BankTransferInAdvanceRequestFactory factory;
 
     @Before
     public void setUp() throws Exception {
@@ -48,7 +48,7 @@ public class BankTransferInAdvanceRequestFactoryTest extends BaseTenantPropertyT
         //clear secure key to force unencrypted data
         when(tenantPropertyProvider.getTenantProperty(TenantPropertyProvider.SECURE_KEY)).thenReturn(Optional.of(""));
 
-        factory = new BanktTransferInAdvanceRequestFactory(tenantConfig);
+        factory = new BankTransferInAdvanceRequestFactory(tenantConfig);
 
         Payment payment = payments.dummyPaymentOneAuthPending20EuroVOR();
         Order order = payments.dummyOrderMapToPayoneRequest();


### PR DESCRIPTION
Just minor change: in case a customer creates a CTP transaction `CHARGE` (Payone _authorization_) we print a warning in the logs to notify them the transaction might be not supported by the service.

Despite Payone service accepts and handles this transaction type, BUT it is explicitly documented:
> 3.2.2 Initiating payment process (authorization)
> Prepayment Not supported by this request!

Also, as minor boy-scout change: renamed typo in class name <code>Bank<b>t</b>TransferInAdvanceRequestFactory</code> -> `BankTransferInAdvanceRequestFactory`
