### PR TITLE
Add ClearSecuredValuesSerializer annotation to all sensitive bean fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Name | Is tenant specific | Content | Default
 `TENANT1_CT_START_FROM_SCRATCH`       | Yes | **WARNING** _**Handle with care!**_ If and only if equal, ignoring case, to `"true"` the service will create the custom types it needs. _**Therefor it first deletes all Order, Cart, Payment and Type entities**_. If not yet in the project, the Custom Types are created independently of this parameter (but only deleted and recreated if this parameter is set).  Related: [issue #34](https://github.com/commercetools/commercetools-payone-integration/issues/34). | `"false"`
 `TENANT1_SECURE_KEY`                  | Yes | if provided and not empty, the value is used as the key for decrypting data from fields "IBAN" and "BIC" for payments with CustomType "PAYMENT_BANK_TRANSFER". The data must be the result of a Blowfish ECB encryption with said key and encoded in HEX. | "" (empty String)
 `TENANT1_UPDATE_ORDER_PAYMENT_STATE`  | Yes | if _true_ - `Order#paymentState` will be updated when payment status notification is received from Payone. By default the order's state remains unchanged. See [Order Payment Status Mapping](/docs/Order-Payment-Status-Mapping.md) for more details. | "false"
+`HIDE_CUSTOMER_PERSONAL_DATA`         | No  | if _true_ - all customer related personal data will be replaced by `<HIDDEN>` placeholder in all logs. If _false_ - all customer related personal data will be visible in logs. | "true"
 
 #### Docker run
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/config/PropertyProvider.java
@@ -32,6 +32,7 @@ public class PropertyProvider {
 
     public static final String SHORT_TIME_FRAME_SCHEDULED_JOB_CRON = "SHORT_TIME_FRAME_SCHEDULED_JOB_CRON";
     public static final String LONG_TIME_FRAME_SCHEDULED_JOB_CRON = "LONG_TIME_FRAME_SCHEDULED_JOB_CRON";
+    public static final String HIDE_CUSTOMER_PERSONAL_DATA = "HIDE_CUSTOMER_PERSONAL_DATA";
 
     private final ImmutableMap<String, String> internalProperties;
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/banktransfer/BankTransferRequest.java
@@ -20,10 +20,10 @@ public class BankTransferRequest extends AuthorizationRequest {
 
     private String bankcountry;
 
-    @ClearSecuredValuesSerializer.Apply
+    @ClearSecuredValuesSerializer.Apply(true)
     private String iban;
 
-    @ClearSecuredValuesSerializer.Apply
+    @ClearSecuredValuesSerializer.Apply(true)
     private String bic;
 
     /**

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.payone.domain.payone.model.common;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
+import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
 
 /**
  * @author fhaertig
@@ -21,66 +22,96 @@ public class AuthorizationRequest extends BaseRequest {
 
     private String currency;
 
+    @ClearSecuredValuesSerializer.Apply
     private String lastname;
 
+    @ClearSecuredValuesSerializer.Apply
     private String country;
 
+    @ClearSecuredValuesSerializer.Apply
     private String param;
 
+    @ClearSecuredValuesSerializer.Apply
     private String narrative_text;
 
+    @ClearSecuredValuesSerializer.Apply
     private String customerid;
 
+    @ClearSecuredValuesSerializer.Apply
     private String userid;
 
+    @ClearSecuredValuesSerializer.Apply
     private String salutation;
 
+    @ClearSecuredValuesSerializer.Apply
     private String title;
 
+    @ClearSecuredValuesSerializer.Apply
     private String firstname;
 
+    @ClearSecuredValuesSerializer.Apply
     private String company;
 
+    @ClearSecuredValuesSerializer.Apply
     private String street;
 
+    @ClearSecuredValuesSerializer.Apply
     private String zip;
 
+    @ClearSecuredValuesSerializer.Apply
     private String city;
 
+    @ClearSecuredValuesSerializer.Apply
     private String addressaddition;
 
+    @ClearSecuredValuesSerializer.Apply
     private String state;
 
+    @ClearSecuredValuesSerializer.Apply
     private String email;
 
+    @ClearSecuredValuesSerializer.Apply
     private String telephonenumber;
 
+    @ClearSecuredValuesSerializer.Apply
     private String birthday;
 
+    @ClearSecuredValuesSerializer.Apply
     private String language;
 
     private String vatid;
 
+    @ClearSecuredValuesSerializer.Apply
     private String gender;
 
+    @ClearSecuredValuesSerializer.Apply
     private String personalid;
 
+    @ClearSecuredValuesSerializer.Apply
     private String ip;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_firstname;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_lastname;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_company;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_street;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_zip;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_city;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_state;
 
+    @ClearSecuredValuesSerializer.Apply
     private String shipping_country;
 
     private String successurl;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/BaseRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/BaseRequest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 public class BaseRequest implements Serializable {
 
     private static final long serialVersionUID = 2L;
-
     /**
      * ID of the merchant
      */
@@ -30,7 +29,7 @@ public class BaseRequest implements Serializable {
     /**
      * Configurable key of payment portal
      */
-    @ClearSecuredValuesSerializer.Apply
+    @ClearSecuredValuesSerializer.Apply(true)
     private String key;
 
     /**

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/CaptureRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/CaptureRequest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.payone.domain.payone.model.common;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
+import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
 
 /**
  * @author fhaertig
@@ -16,10 +17,12 @@ public class CaptureRequest extends BaseRequest {
 
     private String currency;
 
+    @ClearSecuredValuesSerializer.Apply
     private String narrative_text;
 
     private String capturemode;
 
+    @ClearSecuredValuesSerializer.Apply
     private String invoiceid;
 
     private String invoice_deliverymode;
@@ -28,6 +31,7 @@ public class CaptureRequest extends BaseRequest {
 
     private String invoice_deliveryenddate;
 
+    @ClearSecuredValuesSerializer.Apply
     private String invoiceappendix;
 
     protected CaptureRequest(final PayoneConfig config) {

--- a/service/src/main/java/com/commercetools/pspadapter/payone/util/ClearSecuredValuesSerializer.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/util/ClearSecuredValuesSerializer.java
@@ -20,7 +20,7 @@ import static com.commercetools.pspadapter.payone.config.PropertyProvider.HIDE_C
  * {@code Apply} accepts 1 boolean parameter. If the parameter is {@code true} then the value will be hidden.
  * If the parameter is {@code false} or was not provided then the code will check environment variable
  * {@code HIDE_CUSTOMER_PERSONAL_DATA}. If the value of the environment variable is {@code true} then the
- * field will be hidden
+ * field will be hidden. If the value of environment variable is not provided then it will be counted as {@code true}
  *
  * @author fhaertig
  * @since 19.04.16

--- a/service/src/main/java/com/commercetools/pspadapter/payone/util/ClearSecuredValuesSerializer.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/util/ClearSecuredValuesSerializer.java
@@ -2,9 +2,7 @@ package com.commercetools.pspadapter.payone.util;
 
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
@@ -39,7 +37,7 @@ public class ClearSecuredValuesSerializer extends JsonSerializer<String> impleme
     }
 
     @Override
-    public void serialize(final String value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException, JsonProcessingException {
+    public void serialize(final String value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
         final PropertyProvider propertyProvider = new PropertyProvider();
         final boolean hideCustomerPersonalData = propertyProvider.getProperty(HIDE_CUSTOMER_PERSONAL_DATA)
                 .map(dataString -> !dataString.equals("false"))
@@ -52,7 +50,7 @@ public class ClearSecuredValuesSerializer extends JsonSerializer<String> impleme
     }
 
     @Override
-    public JsonSerializer<?> createContextual(final SerializerProvider prov, final BeanProperty property) throws JsonMappingException {
+    public JsonSerializer<?> createContextual(final SerializerProvider prov, final BeanProperty property) {
         return new ClearSecuredValuesSerializer(property);
     }
 

--- a/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequestTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequestTest.java
@@ -1,0 +1,212 @@
+package com.commercetools.pspadapter.payone.domain.payone.model.common;
+
+import com.commercetools.pspadapter.payone.config.PayoneConfig;
+import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthorizationRequestTest {
+    private static final String requestType = "some-request";
+    private static final String clearingType = "some-clearing";
+    private static final String merchantId = "merchant X";
+    private static final String portalId = "portal 23";
+    private static final String keyHash = "hashed key";
+    private static final String mode = "unit test";
+    private static final String apiVersion = "v.1.2.3";
+    private static final String reference = "someReference";
+    private static final int amount = 123;
+    private static final String currency = "EUR";
+    private static final String lastName = "customerLastName";
+    private static final String country = "customerCountry";
+    private static final String param = "someParam";
+    private static final String narrativeText = "someNarrativeText";
+    private static final String customerId = "customerId";
+    private static final String userId = "userId";
+    private static final String salutation = "Mr";
+    private static final String title = "title";
+    private static final String firstName = "customerFirstName";
+    private static final String company = "customerCompany";
+    private static final String street = "customerStreet";
+    private static final String zip = "customerZip";
+    private static final String city = "customerCity";
+    private static final String addressAddition = "customerAddressAddition";
+    private static final String state = "customerState";
+    private static final String email = "customerEmail";
+    private static final String telephoneNumber = "customerPhone";
+    private static final String birthday = "customerBirthday";
+    private static final String language = "customerLanguage";
+    private static final String vatId = "customerVatId";
+    private static final String gender = "customerGender";
+    private static final String personalId = "personalId";
+    private static final String ip = "customerIp";
+    private static final String shippingFirstName = "shippingFirstName";
+    private static final String shippingLastName = "shippingLastname";
+    private static final String shippingCompany = "shippingCompany";
+    private static final String shippingStreet = "shippingStreet";
+    private static final String shippingZip = "shippingZip";
+    private static final String shippingCity = "shippingCity";
+    private static final String shippingState = "shippingState";
+    private static final String shippingCountry = "shippingCountry";
+    private static final String successUrl = "successUrl";
+    private static final String errorUrl = "errorUrl";
+    private static final String backUrl = "backUrl";
+
+    @Mock
+    private PayoneConfig payoneConfig;
+
+    private AuthorizationRequest request;
+
+    @Before
+    public void setUp() {
+        when(payoneConfig.getMerchantId()).thenReturn(merchantId);
+        when(payoneConfig.getPortalId()).thenReturn(portalId);
+        when(payoneConfig.getKeyAsHash()).thenReturn(keyHash);
+        when(payoneConfig.getMode()).thenReturn(mode);
+        when(payoneConfig.getApiVersion()).thenReturn(apiVersion);
+        request = new AuthorizationRequest(payoneConfig, requestType, clearingType);
+        request.setAddressaddition(addressAddition);
+        request.setAmount(amount);
+        request.setBackurl(backUrl);
+        request.setBirthday(birthday);
+        request.setCity(city);
+        request.setCompany(company);
+        request.setCountry(country);
+        request.setCurrency(currency);
+        request.setCustomerid(customerId);
+        request.setEmail(email);
+        request.setErrorurl(errorUrl);
+        request.setFirstname(firstName);
+        request.setGender(gender);
+        request.setIp(ip);
+        request.setLanguage(language);
+        request.setLastname(lastName);
+        request.setNarrative_text(narrativeText);
+        request.setParam(param);
+        request.setPersonalid(personalId);
+        request.setReference(reference);
+        request.setSalutation(salutation);
+        request.setShipping_city(shippingCity);
+        request.setShipping_country(shippingCountry);
+        request.setShipping_company(shippingCompany);
+        request.setShipping_firstname(shippingFirstName);
+        request.setShipping_lastname(shippingLastName);
+        request.setShipping_state(shippingState);
+        request.setShipping_street(shippingStreet);
+        request.setShipping_zip(shippingZip);
+        request.setState(state);
+        request.setStreet(street);
+        request.setSuccessurl(successUrl);
+        request.setTelephonenumber(telephoneNumber);
+        request.setTitle(title);
+        request.setUserid(userId);
+        request.setVatid(vatId);
+        request.setZip(zip);
+    }
+
+    @Test
+    public void createsFullMap() {
+        assertThat(request.toStringMap(false)).containsOnly(
+                entry("narrative_text", narrativeText),
+                entry("param", param),
+                entry("key", keyHash),
+                entry("clearingtype", clearingType),
+                entry("errorurl", errorUrl),
+                entry("vatid", vatId),
+                entry("request", requestType),
+                entry("backurl", backUrl),
+                entry("successurl", successUrl),
+                entry("mode", mode),
+                entry("amount", amount),
+                entry("reference", reference),
+                entry("currency", currency),
+                entry("api_version", apiVersion),
+                entry("portalid", portalId),
+                entry("mid", merchantId),
+                entry("userid", userId),
+                entry("customerid", customerId),
+                entry("personalid", personalId),
+                entry("language", language),
+                entry("birthday", birthday),
+                entry("gender", gender),
+                entry("salutation", salutation),
+                entry("title", title),
+                entry("lastname", lastName),
+                entry("firstname", firstName),
+                entry("country", country),
+                entry("state", state),
+                entry("city", city),
+                entry("street", street),
+                entry("company", company),
+                entry("addressaddition", addressAddition),
+                entry("zip", zip),
+                entry("telephonenumber", telephoneNumber),
+                entry("ip", ip),
+                entry("shipping_firstname", shippingFirstName),
+                entry("shipping_lastname", shippingLastName),
+                entry("shipping_country", shippingCountry),
+                entry("shipping_state", shippingState),
+                entry("shipping_city", shippingCity),
+                entry("shipping_street", shippingStreet),
+                entry("shipping_company", shippingCompany),
+                entry("shipping_zip", shippingZip),
+                entry("email", email));
+
+    }
+
+    @Test
+    public void createsMapWithHiddenSecrets() {
+        assertThat(request.toStringMap(true)).containsOnly(
+                entry("narrative_text", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("param", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("key", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("clearingtype", clearingType),
+                entry("errorurl", errorUrl),
+                entry("vatid", vatId),
+                entry("request", requestType),
+                entry("backurl", backUrl),
+                entry("successurl", successUrl),
+                entry("mode", mode),
+                entry("amount", amount),
+                entry("reference", reference),
+                entry("currency", currency),
+                entry("api_version", apiVersion),
+                entry("portalid", portalId),
+                entry("mid", merchantId),
+                entry("userid", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("customerid", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("personalid", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("language", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("birthday", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("gender", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("salutation", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("title", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("lastname", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("firstname", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("country", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("state", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("city", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("street", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("company", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("zip", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("telephonenumber", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("ip", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("addressaddition", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_firstname", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_lastname", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_country", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_state", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_city", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_street", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_company", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("shipping_zip", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("email", ClearSecuredValuesSerializer.PLACEHOLDER));
+    }
+}

--- a/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequestTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequestTest.java
@@ -2,12 +2,14 @@ package com.commercetools.pspadapter.payone.domain.payone.model.common;
 
 import com.commercetools.pspadapter.payone.config.PayoneConfig;
 import com.commercetools.pspadapter.payone.util.ClearSecuredValuesSerializer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static com.commercetools.pspadapter.payone.config.PropertyProvider.HIDE_CUSTOMER_PERSONAL_DATA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.mockito.Mockito.when;
@@ -111,6 +113,11 @@ public class AuthorizationRequestTest {
         request.setZip(zip);
     }
 
+    @After
+    public void tearDown() {
+        System.clearProperty(HIDE_CUSTOMER_PERSONAL_DATA);
+    }
+
     @Test
     public void createsFullMap() {
         assertThat(request.toStringMap(false)).containsOnly(
@@ -212,7 +219,7 @@ public class AuthorizationRequestTest {
 
     @Test
     public void createsMapWithHiddenSecretsWithoutHidingPersonalData() {
-        System.setProperty("HIDE_CUSTOMER_PERSONAL_DATA", "false");
+        System.setProperty(HIDE_CUSTOMER_PERSONAL_DATA, "false");
 
         assertThat(request.toStringMap(true)).containsOnly(
                 entry("narrative_text", narrativeText),

--- a/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequestTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequestTest.java
@@ -209,4 +209,55 @@ public class AuthorizationRequestTest {
                 entry("shipping_zip", ClearSecuredValuesSerializer.PLACEHOLDER),
                 entry("email", ClearSecuredValuesSerializer.PLACEHOLDER));
     }
+
+    @Test
+    public void createsMapWithHiddenSecretsWithoutHidingPersonalData() {
+        System.setProperty("HIDE_CUSTOMER_PERSONAL_DATA", "false");
+
+        assertThat(request.toStringMap(true)).containsOnly(
+                entry("narrative_text", narrativeText),
+                entry("param", param),
+                entry("key", ClearSecuredValuesSerializer.PLACEHOLDER),
+                entry("clearingtype", clearingType),
+                entry("errorurl", errorUrl),
+                entry("vatid", vatId),
+                entry("request", requestType),
+                entry("backurl", backUrl),
+                entry("successurl", successUrl),
+                entry("mode", mode),
+                entry("amount", amount),
+                entry("reference", reference),
+                entry("currency", currency),
+                entry("api_version", apiVersion),
+                entry("portalid", portalId),
+                entry("mid", merchantId),
+                entry("userid", userId),
+                entry("customerid", customerId),
+                entry("personalid", personalId),
+                entry("language", language),
+                entry("birthday", birthday),
+                entry("gender", gender),
+                entry("salutation", salutation),
+                entry("title", title),
+                entry("lastname", lastName),
+                entry("firstname", firstName),
+                entry("country", country),
+                entry("state", state),
+                entry("city", city),
+                entry("street", street),
+                entry("company", company),
+                entry("addressaddition", addressAddition),
+                entry("zip", zip),
+                entry("telephonenumber", telephoneNumber),
+                entry("ip", ip),
+                entry("shipping_firstname", shippingFirstName),
+                entry("shipping_lastname", shippingLastName),
+                entry("shipping_country", shippingCountry),
+                entry("shipping_state", shippingState),
+                entry("shipping_city", shippingCity),
+                entry("shipping_street", shippingStreet),
+                entry("shipping_company", shippingCompany),
+                entry("shipping_zip", shippingZip),
+                entry("email", email));
+    }
 }


### PR DESCRIPTION
## Description
Customer related data shouldn't be logged. Therefore we need to provide a switch in the configuration which allows to anonymise/de-anonymise those data.
This switch implemented as an environment variable `HIDE_CUSTOMER_PERSONAL_DATA` which can be in 2 states: `"true"` OR `"false"`.
Default state is `"true"`. So if the environment variable is not provided then customer related data will be replaced by `<HIDDEN>` placeholder.