### PR TITLE
Using testurl with https.

### DIFF
--- a/functionaltests/src/test/resources/specs/paymentmethods/paydirekt/Authorization.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/paydirekt/Authorization.html
@@ -122,8 +122,8 @@
         <tr>
             <th c:set="#paymentName">Payment Name</th>
             <th c:assertEquals="#result.transactionState">Transaction State </th>
-            <th c:assertEquals="containsSubstring(#result.responseRedirectUrlFull, 'https://sandbox.paydirekt.de/checkout/#/checkout/')">
-                redirect URL contains 'https://sandbox.paydirekt.de/checkout/#/checkout/'</th>
+            <th c:assertEquals="containsSubstring(#result.responseRedirectUrlFull, 'https://sandbox.paydirekt.de/checkout/')">
+                redirect URL contains 'https://sandbox.paydirekt.de/checkout/'</th>
             <th c:echo="#result.responseRedirectUrlFull">full redirect URL (for information only)</th>
             <th c:echo="#result.version">Version (for information only)</th>
         </tr>

--- a/functionaltests/src/test/resources/specs/paymentmethods/paydirekt/ChargeImmediately.html
+++ b/functionaltests/src/test/resources/specs/paymentmethods/paydirekt/ChargeImmediately.html
@@ -123,8 +123,8 @@
                 <tr>
                     <th c:set="#paymentName">Payment Name</th>
                     <th c:assertEquals="#result.transactionState">Transaction State </th>
-                    <th c:assertEquals="containsSubstring(#result.responseRedirectUrlFull, 'https://sandbox.paydirekt.de/checkout/#/checkout/')">
-                        redirect URL contains 'https://sandbox.paydirekt.de/checkout/#/checkout/'</th>
+                    <th c:assertEquals="containsSubstring(#result.responseRedirectUrlFull, 'https://sandbox.paydirekt.de/checkout/')">
+                        redirect URL contains 'https://sandbox.paydirekt.de/checkout/'</th>
                     <th c:echo="#result.responseRedirectUrlFull">full redirect URL (for information only)</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>
@@ -212,8 +212,8 @@
                 <tr>
                     <th c:set="#paymentName">Payment Name</th>
                     <th c:assertEquals="#result.transactionState">Transaction State </th>
-                    <th c:assertEquals="containsSubstring(#result.responseRedirectUrlFull, 'https://sandbox.paydirekt.de/checkout/#/checkout/')">
-                        redirect URL contains 'https://sandbox.paydirekt.de/checkout/#/checkout/'</th>
+                    <th c:assertEquals="containsSubstring(#result.responseRedirectUrlFull, 'https://sandbox.paydirekt.de/checkout/')">
+                        redirect URL contains 'https://sandbox.paydirekt.de/checkout/'</th>
                     <th c:echo="#result.responseRedirectUrlFull">full redirect URL (for information only)</th>
                     <th c:echo="#result.version">Version (for information only)</th>
                 </tr>

--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilParallelTest.java
@@ -46,7 +46,7 @@ public class HttpRequestUtilParallelTest {
 
     @Test
     public void executePostRequest_shouldBeParalleled() throws Exception {
-        ExceptionalSupplier<HttpResponse> postRequestSupplier = () -> executePostRequest(HTTP_HTTPBIN_ORG_POST, asList(
+        ExceptionalSupplier<HttpResponse> postRequestSupplier = () -> executePostRequest(HTTPS_HTTPBIN_ORG_POST, asList(
                 nameValue("xxx", "yyy"),
                 nameValue("zzz", 11223344)));
 
@@ -82,7 +82,7 @@ public class HttpRequestUtilParallelTest {
                 do {
                     if (repeatedTimes > 0) {
                         LOGGER.warn("{} \"Request Timeout\" received from [{}]. Retry {} of {} ...",
-                                SC_REQUEST_TIMEOUT, HTTP_HTTPBIN_ORG, repeatedTimes, RETRY_TIMES);
+                                SC_REQUEST_TIMEOUT, HTTPS_HTTPBIN_ORG, repeatedTimes, RETRY_TIMES);
                     }
                     httpResponse = responseSupplier.get();
                     statusCode = httpResponse.getStatusLine().getStatusCode();

--- a/service/src/test/java/com/commercetools/util/HttpRequestUtilTest.java
+++ b/service/src/test/java/com/commercetools/util/HttpRequestUtilTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.data.MapEntry.entry;
 
 public class HttpRequestUtilTest {
 
-    static final String HTTP_HTTPBIN_ORG = "http://httpbin.org/";
-    static final String HTTP_HTTPBIN_ORG_GET = HTTP_HTTPBIN_ORG + "get";
-    static final String HTTP_HTTPBIN_ORG_POST = HTTP_HTTPBIN_ORG + "post";
+    static final String HTTPS_HTTPBIN_ORG = "https://httpbin.org/";
+    static final String HTTP_HTTPBIN_ORG_GET = HTTPS_HTTPBIN_ORG + "get";
+    static final String HTTPS_HTTPBIN_ORG_POST = HTTPS_HTTPBIN_ORG + "post";
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 
@@ -38,22 +38,22 @@ public class HttpRequestUtilTest {
 
     @Test
     public void executePostRequest_isSuccessful() throws Exception {
-        HttpResponse response = executePostRequest(HTTP_HTTPBIN_ORG_POST, singletonList(nameValue("a", "b")));
+        HttpResponse response = executePostRequest(HTTPS_HTTPBIN_ORG_POST, singletonList(nameValue("a", "b")));
         assertThat(response.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
     }
 
     @Test
     public void executePostRequestToString_returnsStringContainingRequestArguments() throws Exception {
-        assertThat(executePostRequestToString(HTTP_HTTPBIN_ORG_POST, asList(
+        assertThat(executePostRequestToString(HTTPS_HTTPBIN_ORG_POST, asList(
                 nameValue("aaa", "bbb"),
                 nameValue("ccc", 89456677823452345L))))
-                .contains(HTTP_HTTPBIN_ORG_POST, "aaa", "bbb", "ccc", "89456677823452345");
+                .contains(HTTPS_HTTPBIN_ORG_POST, "aaa", "bbb", "ccc", "89456677823452345");
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void shortPostRequestWithArguments_shouldSuccess() throws Exception {
-        final HttpResponse httpResponse = executePostRequest(HTTP_HTTPBIN_ORG_POST, ImmutableList.of(
+        final HttpResponse httpResponse = executePostRequest(HTTPS_HTTPBIN_ORG_POST, ImmutableList.of(
                 nameValue("a", "b"),
                 nameValue("hello", 22),
                 nameValue("Fußgängerübergänge", "Пішохідні переходи"),
@@ -77,7 +77,7 @@ public class HttpRequestUtilTest {
 
     @Test
     public void shortPostRequestWithoutArguments_shouldSuccess() throws Exception {
-        final HttpResponse httpResponse = executePostRequest(HTTP_HTTPBIN_ORG_POST, null);
+        final HttpResponse httpResponse = executePostRequest(HTTPS_HTTPBIN_ORG_POST, null);
         assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(HttpStatusCode.OK_200);
     }
 }


### PR DESCRIPTION
In this pr, a JUnit test, with used 'httpbin' for testing requests, is fixed. The problem was,if the request "httpbin.org/post" was executes in "Http" context, this url was added to the response as "http://httpbin.org/post". This behavior has change, so that now the url is always added with as "https://httpbin.org/post" to the response.