### PR TITLE
CAR-2726 remove ctp payment checks from health endpoint

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
@@ -22,9 +22,12 @@ import spark.utils.CollectionUtils;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.commercetools.pspadapter.payone.util.PayoneConstants.PAYONE;
 import static io.sphere.sdk.json.SphereJsonUtils.toJsonString;
@@ -40,9 +43,8 @@ import static java.util.stream.Collectors.toMap;
 public class IntegrationService {
 
     public static final Logger LOG = LoggerFactory.getLogger(IntegrationService.class);
-    static final int ERROR_STATUS = HttpStatus.SERVICE_UNAVAILABLE_503;
     static final int SUCCESS_STATUS = HttpStatus.OK_200;
-    static final String STATUS_KEY = "status";
+    private static final String STATUS_KEY = "status";
     static final String TENANTS_KEY = "tenants";
     static final String APPLICATION_INFO_KEY = "applicationInfo";
 
@@ -146,6 +148,10 @@ public class IntegrationService {
     private void initSparkService() {
         Spark.port(port());
 
+        final ImmutableMap<String, Object> healthResponse = createHealthResponse(serviceConfig, tenantFactories);
+        final String healthRequestContent = toJsonString(healthResponse);
+        final String healthRequestFormattedContent = toPrettyJsonString(healthResponse);
+
         // This is a temporary jerry-rig for the load balancer to check connection with the service itself.
         // For now it just returns a JSON response with status code, tenants list and static application info.
         // It should be expanded to a more real health-checker service, which really performs PAYONE status check.
@@ -154,12 +160,9 @@ public class IntegrationService {
         LOG.info("Register /health URL");
         LOG.info("Use /health?pretty to pretty-print output JSON");
         Spark.get("/health", (req, res) -> {
-            ImmutableMap<String, Object> healthResponse = createHealthResponse(serviceConfig, tenantFactories);
-            res.status((Integer) healthResponse.getOrDefault(STATUS_KEY, ERROR_STATUS));
+            res.status(SUCCESS_STATUS);
             res.type(ContentType.APPLICATION_JSON.getMimeType());
-
-            return req.queryParams("pretty") != null ? toPrettyJsonString(healthResponse) :
-                    toJsonString(healthResponse);
+            return req.queryParams("pretty") != null ? healthRequestFormattedContent : healthRequestContent;
         });
     }
 
@@ -182,29 +185,15 @@ public class IntegrationService {
         final ImmutableMap<String, String> applicationInfo = ImmutableMap.of(
                 "version", serviceConfig.getApplicationVersion(),
                 "title", serviceConfig.getApplicationName());
-        Map<String, CompletionStage<Integer>> tenantMap = checkTenantStatuses(tenants);
-        //resolve all completable stages
-        listOfFuturesToFutureOfList(new ArrayList<>(tenantMap.values())).join();
-        //unpack completable features
-        Map<String, Integer> statusMap = tenantMap.keySet().stream()
-                .collect(toMap(tenant -> tenant, tenant -> tenantMap.get(tenant).toCompletableFuture().join()));
-        return ImmutableMap.of(
-                STATUS_KEY, !statusMap.containsValue(ERROR_STATUS) ? SUCCESS_STATUS : ERROR_STATUS,
-                TENANTS_KEY, statusMap,
-                APPLICATION_INFO_KEY, applicationInfo);
-    }
 
-    private Map<String, CompletionStage<Integer>> checkTenantStatuses(List<TenantFactory> tenants) {
-        return tenants.stream().collect(toMap(TenantFactory::getTenantName, tenantFactory -> {
-            final String tenantName = tenantFactory.getTenantName();
-            return tenantFactory.getBlockingSphereClient().execute(PaymentQuery.of().withLimit(0l))
-                    .handle((result, exception) -> {
-                        if (result != null) {
-                            return SUCCESS_STATUS;
-                        }
-                        LOG.error("Cannot query payments for the tenant {}", tenantName, exception);
-                        return ERROR_STATUS;
-                    });
-        }));
+        final Map<String, Integer> tenantStatues = new HashMap<>();
+        for (TenantFactory tenant : tenants) {
+            tenantStatues.put(tenant.getTenantName(), SUCCESS_STATUS);
+        }
+
+        return ImmutableMap.of(
+                STATUS_KEY, SUCCESS_STATUS,
+                TENANTS_KEY, tenantStatues,
+                APPLICATION_INFO_KEY, applicationInfo);
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
@@ -20,9 +20,7 @@ import spark.utils.CollectionUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.commercetools.pspadapter.payone.util.PayoneConstants.PAYONE;
 import static io.sphere.sdk.json.SphereJsonUtils.toJsonString;
@@ -38,8 +36,7 @@ public class IntegrationService {
     public static final Logger LOG = LoggerFactory.getLogger(IntegrationService.class);
     static final int SUCCESS_STATUS = HttpStatus.OK_200;
     private static final String STATUS_KEY = "status";
-    static final String TENANTS_KEY = "tenants";
-    static final String APPLICATION_INFO_KEY = "applicationInfo";
+    private static final String APPLICATION_INFO_KEY = "applicationInfo";
 
     private static final String HEROKU_ASSIGNED_PORT = "PORT";
     private List<TenantFactory> tenantFactories = null;
@@ -143,7 +140,7 @@ public class IntegrationService {
 
         final ImmutableMap<String, Object> healthResponse = createHealthResponse(serviceConfig, tenantFactories);
         final String healthRequestContent = toJsonString(healthResponse);
-        final String healthRequestFormattedContent = toPrettyJsonString(healthResponse);
+        final String healthRequestPrettyContent = toPrettyJsonString(healthResponse);
 
         // This is a temporary jerry-rig for the load balancer to check connection with the service itself.
         // For now it just returns a JSON response with status code, tenants list and static application info.
@@ -155,7 +152,7 @@ public class IntegrationService {
         Spark.get("/health", (req, res) -> {
             res.status(SUCCESS_STATUS);
             res.type(ContentType.APPLICATION_JSON.getMimeType());
-            return req.queryParams("pretty") != null ? healthRequestFormattedContent : healthRequestContent;
+            return req.queryParams("pretty") != null ? healthRequestPrettyContent : healthRequestContent;
         });
     }
 
@@ -179,14 +176,8 @@ public class IntegrationService {
                 "version", serviceConfig.getApplicationVersion(),
                 "title", serviceConfig.getApplicationName());
 
-        final Map<String, Integer> tenantStatutes = new HashMap<>();
-        for (TenantFactory tenant : tenants) {
-            tenantStatutes.put(tenant.getTenantName(), SUCCESS_STATUS);
-        }
-
         return ImmutableMap.of(
                 STATUS_KEY, SUCCESS_STATUS,
-                TENANTS_KEY, tenantStatutes,
                 APPLICATION_INFO_KEY, applicationInfo);
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
@@ -186,14 +186,14 @@ public class IntegrationService {
                 "version", serviceConfig.getApplicationVersion(),
                 "title", serviceConfig.getApplicationName());
 
-        final Map<String, Integer> tenantStatues = new HashMap<>();
+        final Map<String, Integer> tenantStatutes = new HashMap<>();
         for (TenantFactory tenant : tenants) {
-            tenantStatues.put(tenant.getTenantName(), SUCCESS_STATUS);
+            tenantStatutes.put(tenant.getTenantName(), SUCCESS_STATUS);
         }
 
         return ImmutableMap.of(
                 STATUS_KEY, SUCCESS_STATUS,
-                TENANTS_KEY, tenantStatues,
+                TENANTS_KEY, tenantStatutes,
                 APPLICATION_INFO_KEY, applicationInfo);
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/IntegrationService.java
@@ -10,7 +10,6 @@ import com.commercetools.pspadapter.tenant.TenantFactory;
 import com.commercetools.pspadapter.tenant.TenantPropertyProvider;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import io.sphere.sdk.payments.queries.PaymentQuery;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
 import org.eclipse.jetty.http.HttpStatus;
@@ -20,21 +19,15 @@ import spark.Spark;
 import spark.utils.CollectionUtils;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.commercetools.pspadapter.payone.util.PayoneConstants.PAYONE;
 import static io.sphere.sdk.json.SphereJsonUtils.toJsonString;
 import static io.sphere.sdk.json.SphereJsonUtils.toPrettyJsonString;
-import static io.sphere.sdk.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * @author fhaertig

--- a/service/src/test/java/com/commercetools/pspadapter/payone/IntegrationServiceTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/IntegrationServiceTest.java
@@ -2,26 +2,17 @@ package com.commercetools.pspadapter.payone;
 
 import com.commercetools.pspadapter.payone.config.ServiceConfig;
 import com.commercetools.pspadapter.tenant.TenantFactory;
-import io.sphere.sdk.client.BlockingSphereClient;
-import io.sphere.sdk.client.SphereTimeoutException;
-import io.sphere.sdk.queries.PagedQueryResult;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import spark.Spark;
 import spark.utils.IOUtils;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.List;
-import java.util.concurrent.TimeoutException;
 
-import static com.commercetools.pspadapter.payone.IntegrationService.ERROR_STATUS;
 import static com.commercetools.pspadapter.payone.IntegrationService.SUCCESS_STATUS;
 import static com.google.common.collect.ImmutableList.of;
-import static io.sphere.sdk.utils.CompletableFutureUtils.exceptionallyCompletedFuture;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static spark.Spark.awaitStop;
@@ -32,11 +23,11 @@ public class IntegrationServiceTest {
     private static final String APPLICATION_TITLE = "applicationTitle";
     private static final String TENANTNAME1 = "tenant1";
     private static final String TENANTNAME2 = "tenant2";
-    IntegrationService integrationService = null;
+    private IntegrationService integrationService = null;
 
     private ServiceConfig serviceConfig = null;
 
-    private static HealthResponse request() {
+    private static HealthResponse requestHealth() {
         try {
             URL url = new URL("http://localhost:8080/health");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -72,52 +63,20 @@ public class IntegrationServiceTest {
 
     @Test
     public void createHealthResponse_tenantConfigIsWorking_shouldReturnOkStatus() {
-        List<TenantFactory> tenantFactories = of(createTenantFactory(TENANTNAME1, false),
-                createTenantFactory(TENANTNAME2, false));
-        integrationService = new IntegrationService(serviceConfig, tenantFactories);
+        integrationService = new IntegrationService(serviceConfig, of(
+                createMockTenantFactory(TENANTNAME1),
+                createMockTenantFactory(TENANTNAME2)));
+
         integrationService.start();
 
-        HealthResponse result = request();
+        final HealthResponse result = requestHealth();
+
         assertThat(result.status).isEqualTo(SUCCESS_STATUS);
         assertThat(result.body).isEqualTo(expectedBody(SUCCESS_STATUS, SUCCESS_STATUS, SUCCESS_STATUS));
- }
-
-    @Test
-    public void createHealthResponse_allTenantsAreNotWorking_shouldReturnErrorStatus() {
-        List<TenantFactory> tenantFactories = of(createTenantFactory(TENANTNAME1, true),
-                createTenantFactory(TENANTNAME2, true));
-        integrationService = new IntegrationService(serviceConfig, tenantFactories);
-        integrationService.start();
-
-        HealthResponse result = request();
-        assertThat(result.status).isEqualTo(ERROR_STATUS);
-        assertThat(result.body).isEqualTo(expectedBody(ERROR_STATUS, ERROR_STATUS, ERROR_STATUS));
-
     }
 
-    @Test
-    public void createHealthResponse_oneTenantIsNotWorking_shouldReturnErrorStatus() {
-        List<TenantFactory> tenantFactories = of(createTenantFactory(TENANTNAME1, true),
-                createTenantFactory(TENANTNAME2, false));
-        integrationService = new IntegrationService(serviceConfig, tenantFactories);
-        integrationService.start();
-
-        HealthResponse result = request();
-        assertThat(result.status).isEqualTo(ERROR_STATUS);
-        assertThat(result.body).isEqualTo(expectedBody(ERROR_STATUS, ERROR_STATUS, SUCCESS_STATUS));
-
-    }
-
-    private TenantFactory createTenantFactory(String tenantName, boolean erroneous) {
+    private TenantFactory createMockTenantFactory(String tenantName) {
         TenantFactory tenantFactory = Mockito.mock(TenantFactory.class);
-        BlockingSphereClient client = Mockito.mock(BlockingSphereClient.class);
-        if (erroneous) {
-            when(client.execute(Mockito.anyObject())).thenReturn(exceptionallyCompletedFuture(new SphereTimeoutException(new TimeoutException())));
-        } else {
-            PagedQueryResult mockResult = Mockito.mock(PagedQueryResult.class);
-            when(client.execute(Mockito.anyObject())).thenReturn(completedFuture(mockResult));
-        }
-        when(tenantFactory.getBlockingSphereClient()).thenReturn(client);
         when(tenantFactory.getTenantName()).thenReturn(tenantName);
         return tenantFactory;
     }


### PR DESCRIPTION
The current implementation is causing some problems if ctp is failing with `504` or `500` status. So k8s restarting pod because of the platform issue, this leads some unexpected restarts.

with this PR, if the health endpoint is working, it will return HTTP ok (200) when it called by k8s  liveness/readiness probes. 

JIRA ticket: https://jira.commercetools.com/browse/CAR-2726