### PR TITLE
Remove redundant logs

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -80,7 +80,7 @@ public class PaymentHandler {
         }
     }
 
-    private PaymentHandleResult processPayment(@Nonnull final String paymentId) {
+    private PaymentHandleResult processPayment(@Nonnull final String paymentId) throws ConcurrentModificationException {
         final PaymentWithCartLike paymentWithCartLike =
             commercetoolsQueryExecutor
                 .getPaymentWithCartLike(paymentId);

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -91,8 +91,8 @@ public class PaymentHandler {
             .getPaymentInterface();
 
         if (!payoneInterfaceName.equals(paymentInterface)) {
-            final String errorMessage = format("Wrong payment interface name: expected '%s', found '%s'",
-                payoneInterfaceName, paymentInterface);
+            final String errorMessage = format("Wrong payment interface name: expected '%s', found '%s' for the "
+                + "commercetools Payment with id '%s'.", payoneInterfaceName, paymentInterface, paymentId);
             return new PaymentHandleResult(HttpStatusCode.BAD_REQUEST_400, errorMessage);
         }
 
@@ -126,7 +126,7 @@ public class PaymentHandler {
         logger.error(tenantNameKeyValue,
             format("Failed to process the commercetools Payment with id [%s] due to an error response from the commercetools platform.", paymentId), e);
         return new PaymentHandleResult(e.getStatusCode(),
-                format("Failed to process the commercetools payment with id [%s], due to an error response from the "
+                format("Failed to process the commercetools Payment with id [%s], due to an error response from the "
                     + "commercetools platform. Try again later.", paymentId));
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -91,10 +91,9 @@ public class PaymentHandler {
             .getPaymentInterface();
 
         if (!payoneInterfaceName.equals(paymentInterface)) {
-            logger.warn(tenantNameKeyValue,
-                "Wrong payment interface name: expected [{}], found [{}]",
+            final String errorMessage = format("Wrong payment interface name: expected '%s', found '%s'",
                 payoneInterfaceName, paymentInterface);
-            return new PaymentHandleResult(HttpStatusCode.BAD_REQUEST_400);
+            return new PaymentHandleResult(HttpStatusCode.BAD_REQUEST_400, errorMessage);
         }
 
         paymentDispatcher.dispatchPayment(paymentWithCartLike);

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -56,11 +56,11 @@ public class PaymentHandler {
         return handlePayment(paymentId, 0);
     }
 
-    public PaymentHandleResult handlePayment(@Nonnull final String paymentId, final int currentAttemptCount) {
+    private PaymentHandleResult handlePayment(@Nonnull final String paymentId, final int currentAttemptCount) {
         try {
             if (currentAttemptCount < RETRIES_LIMIT) {
                 return attemptToProcessPayment(paymentId, currentAttemptCount)
-                    .orElseGet(() -> handlePayment(paymentId, currentAttemptCount -1));
+                    .orElseGet(() -> handlePayment(paymentId, currentAttemptCount + 1));
             }
             throw new IllegalStateException("Unexpected logical path. This line should be unreachable as long as "
                 + "RETRIES_LIMIT > 0");

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -52,7 +52,7 @@ public class PaymentHandler {
      */
     public PaymentHandleResult handlePayment(@Nonnull final String paymentId) {
         try {
-            return attemptToProcessPayment(paymentId, 0);
+            return processPaymentOrRetry(paymentId, 0);
         } catch (final ConcurrentModificationException concurrentModificationException) {
             return handleConcurrentModificationException(paymentId, concurrentModificationException);
         } catch (final NotFoundException | NoCartLikeFoundException e) {
@@ -64,7 +64,7 @@ public class PaymentHandler {
         }
     }
 
-    private PaymentHandleResult attemptToProcessPayment(
+    private PaymentHandleResult processPaymentOrRetry(
         @Nonnull final String paymentId,
         final int currentAttemptCount) throws InterruptedException {
 
@@ -75,7 +75,7 @@ public class PaymentHandler {
                 throw concurrentModificationException;
             } else {
                 Thread.sleep(RETRY_DELAY);
-                return attemptToProcessPayment(paymentId, currentAttemptCount + 1);
+                return processPaymentOrRetry(paymentId, currentAttemptCount + 1);
             }
         }
     }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -14,11 +14,10 @@ import javax.annotation.Nonnull;
 import java.util.ConcurrentModificationException;
 import java.util.concurrent.CompletionException;
 
-import static com.commercetools.pspadapter.tenant.TenantLoggerUtil.createLoggerName;
+import static com.commercetools.pspadapter.tenant.TenantLoggerUtil.createTenantKeyValue;
 import static io.sphere.sdk.http.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static net.logstash.logback.marker.Markers.append;
 
 public class PaymentHandler {
 
@@ -43,8 +42,8 @@ public class PaymentHandler {
         this.commercetoolsQueryExecutor = commercetoolsQueryExecutor;
         this.paymentDispatcher = paymentDispatcher;
 
-        this.logger = LoggerFactory.getLogger(createLoggerName(this.getClass(), tenantName));
-        tenantNameKeyValue = append("tenantName", tenantName);
+        this.logger = LoggerFactory.getLogger(this.getClass());
+        tenantNameKeyValue = createTenantKeyValue(tenantName);
     }
 
     /**

--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -52,15 +52,19 @@ public class PaymentHandler {
      */
     public PaymentHandleResult handlePayment(@Nonnull final String paymentId) {
         try {
-            ConcurrentModificationException lastConcurrentModificationException = null;
             for (int i = 0; i < RETRIES_LIMIT; i++) {
                 try {
-                    final PaymentWithCartLike paymentWithCartLike = commercetoolsQueryExecutor
-                        .getPaymentWithCartLike(paymentId);
-                    String paymentInterface = paymentWithCartLike.getPayment().getPaymentMethodInfo()
-                                                                 .getPaymentInterface();
+                    final PaymentWithCartLike paymentWithCartLike =
+                        commercetoolsQueryExecutor.getPaymentWithCartLike(paymentId);
+
+                    final String paymentInterface = paymentWithCartLike
+                        .getPayment()
+                        .getPaymentMethodInfo()
+                        .getPaymentInterface();
+
                     if (!payoneInterfaceName.equals(paymentInterface)) {
-                        logger.warn(tenantNameKeyValue, "Wrong payment interface name: expected [{}], found [{}]",
+                        logger.warn(tenantNameKeyValue,
+                            "Wrong payment interface name: expected [{}], found [{}]",
                             payoneInterfaceName, paymentInterface);
                         return new PaymentHandleResult(HttpStatusCode.BAD_REQUEST_400);
                     }
@@ -68,14 +72,14 @@ public class PaymentHandler {
                     paymentDispatcher.dispatchPayment(paymentWithCartLike);
                     return new PaymentHandleResult(HttpStatusCode.OK_200);
                 } catch (final ConcurrentModificationException concurrentModificationException) {
-                    lastConcurrentModificationException = concurrentModificationException;
+                    if (i == RETRIES_LIMIT - 1) {
+                        return handleConcurrentModificationException(paymentId, concurrentModificationException);
+                    }
                     Thread.sleep(RETRY_DELAY);
                 }
             }
-            throw lastConcurrentModificationException;
-        }
-        catch (final ConcurrentModificationException concurrentModificationException) {
-            return handleConcurrentModificationException(paymentId, concurrentModificationException);
+            throw new IllegalStateException("Unexpected logical path. This line should be unreachable as long as "
+                + "RETRIES_LIMIT > 0");
         } catch (final NotFoundException | NoCartLikeFoundException e) {
             return handleNotFoundException(paymentId, e);
         } catch (final ErrorResponseException e) {
@@ -95,13 +99,19 @@ public class PaymentHandler {
         return new PaymentHandleResult(HttpStatusCode.ACCEPTED_202, errorMessage);
     }
 
-    private PaymentHandleResult handleNotFoundException(@Nonnull String paymentId, @Nonnull Exception exception ) {
+    private PaymentHandleResult handleNotFoundException(
+        @Nonnull final String paymentId,
+        @Nonnull final Exception exception ) {
+
         final String body = format("Failed to process the commercetools Payment with id [%s], as the payment or the cart could not be found.", paymentId);
         logger.error(tenantNameKeyValue, body, exception);
         return new PaymentHandleResult(HttpStatusCode.NOT_FOUND_404, body);
     }
 
-    private PaymentHandleResult errorResponseHandler(@Nonnull ErrorResponseException e, @Nonnull String paymentId) {
+    private PaymentHandleResult errorResponseHandler(
+        @Nonnull final ErrorResponseException e,
+        @Nonnull final String paymentId) {
+
         logger.error(tenantNameKeyValue,
             format("Failed to process the commercetools Payment with id [%s] due to an error response from the commercetools platform.", paymentId), e);
         return new PaymentHandleResult(e.getStatusCode(),
@@ -109,9 +119,12 @@ public class PaymentHandler {
                     + "commercetools platform. Try again later.", paymentId));
     }
 
-    private PaymentHandleResult handleException(@Nonnull Exception throwable, @Nonnull String paymentId) {
+    private PaymentHandleResult handleException(
+        @Nonnull final Exception exception,
+        @Nonnull final String paymentId) {
+
         logger.error(tenantNameKeyValue,
-            format("Unexpected error occurred when processing commercetools Payment with id [%s].", paymentId), throwable);
+            format("Unexpected error occurred when processing commercetools Payment with id [%s].", paymentId), exception);
         return new PaymentHandleResult(INTERNAL_SERVER_ERROR_500,
                 format("Unexpected error occurred when processing commercetools Payment with id [%s]. "
                     + "See the service logs", paymentId));

--- a/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
@@ -45,7 +45,7 @@ public abstract class ScheduledJob implements Job {
                         .getPaymentWithCartLike(payment.getId(), CompletableFuture.completedFuture(payment));
                     paymentDispatcher.dispatchPayment(paymentWithCartLike);
                 } catch (final NoCartLikeFoundException ex) {
-                    LOG.debug(
+                    LOG.error(//TODO: Ask Roman why it was info
                         createTenantKeyValue(tenantFactory.getTenantName()),
                         format("Could not dispatch payment with id '%s'", payment.getId()),
                         ex);

--- a/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
@@ -45,7 +45,7 @@ public abstract class ScheduledJob implements Job {
                         .getPaymentWithCartLike(payment.getId(), CompletableFuture.completedFuture(payment));
                     paymentDispatcher.dispatchPayment(paymentWithCartLike);
                 } catch (final NoCartLikeFoundException ex) {
-                    LOG.error(//TODO: Ask Roman why it was info
+                    LOG.error(
                         createTenantKeyValue(tenantFactory.getTenantName()),
                         format("Could not dispatch payment with id '%s'", payment.getId()),
                         ex);

--- a/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/ScheduledJob.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import static com.commercetools.pspadapter.tenant.TenantLoggerUtil.createTenantKeyValue;
+import static java.lang.String.format;
 
 /**
  * @author fhaertig
@@ -44,15 +45,20 @@ public abstract class ScheduledJob implements Job {
                         .getPaymentWithCartLike(payment.getId(), CompletableFuture.completedFuture(payment));
                     paymentDispatcher.dispatchPayment(paymentWithCartLike);
                 } catch (final NoCartLikeFoundException ex) {
-                    LOG.debug(createTenantKeyValue(tenantFactory.getTenantName()),
-                        "Could not dispatch payment with id \"{}\": {}", payment.getId(), ex.getMessage());
+                    LOG.debug(
+                        createTenantKeyValue(tenantFactory.getTenantName()),
+                        format("Could not dispatch payment with id '%s'", payment.getId()),
+                        ex);
                 } catch (final ConcurrentModificationException ex) {
-                    LOG.info(createTenantKeyValue(tenantFactory.getTenantName()),
-                        "Could not dispatch payment with id \"{}\": The payment is currently processed by someone else.",
-                        payment.getId());
+                    LOG.info(
+                        createTenantKeyValue(tenantFactory.getTenantName()),
+                        format("Could not dispatch payment with id '%s': The payment is currently processed by someone else.", payment.getId()),
+                        ex);
                 } catch (final Exception ex) {
-                    LOG.error(createTenantKeyValue(tenantFactory.getTenantName()),
-                        "Error dispatching payment with id \"{}\"", payment.getId(), ex);
+                    LOG.error(
+                        createTenantKeyValue(tenantFactory.getTenantName()),
+                        format("Error dispatching payment with id '%s'", payment.getId()),
+                        ex);
                 }
             };
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
@@ -59,7 +59,7 @@ public class PayonePostServiceImpl implements PayonePostService {
             String serverResponse = executePostRequestToString(this.serverAPIURL, mappedListParameters);
             return buildMapFromResultParams(serverResponse);
         } catch (Exception e) {
-            throw new PayoneException("Payone POST request failed. Cause: " + e.toString(), e);
+            throw new PayoneException("Payone POST request failed." , e);
         }
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
@@ -57,12 +57,6 @@ public class PayonePostServiceImpl implements PayonePostService {
                     getNameValuePairsWithExpandedLists(baseRequest.toStringMap(false));
 
             String serverResponse = executePostRequestToString(this.serverAPIURL, mappedListParameters);
-
-            if (serverResponse.contains("status=ERROR")) {
-                LOG.error("-> Payone POST request parameters: {}",
-                        getNameValuePairsWithExpandedLists(baseRequest.toStringMap(true)).toString());
-                LOG.error("Payone POST response: {}", serverResponse);
-            }
             return buildMapFromResultParams(serverResponse);
         } catch (Exception e) {
             throw new PayoneException("Payone POST request failed. Cause: " + e.toString(), e);

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import static com.commercetools.util.HttpRequestUtil.executePostRequestToString;
 import static com.commercetools.util.HttpRequestUtil.nameValue;
+import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
 public class PayonePostServiceImpl implements PayonePostService {
@@ -53,13 +54,17 @@ public class PayonePostServiceImpl implements PayonePostService {
     public Map<String, String> executePost(final BaseRequest baseRequest) throws PayoneException {
 
         try {
-            List<BasicNameValuePair> mappedListParameters =
+            final List<BasicNameValuePair> mappedListParameters =
                     getNameValuePairsWithExpandedLists(baseRequest.toStringMap(false));
 
-            String serverResponse = executePostRequestToString(this.serverAPIURL, mappedListParameters);
+            final String serverResponse = executePostRequestToString(this.serverAPIURL, mappedListParameters);
+
             return buildMapFromResultParams(serverResponse);
         } catch (Exception e) {
-            throw new PayoneException("Payone POST request failed." , e);
+            final String requestBody =
+                getNameValuePairsWithExpandedLists(baseRequest.toStringMap(true)).toString();
+            final String exceptionMessage = format("Payone POST request with body (%s) failed.", requestBody);
+            throw new PayoneException(exceptionMessage, e);
         }
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
 
 import static com.commercetools.pspadapter.payone.mapping.MappingUtil.getGenderFromPaymentCart;
 import static com.commercetools.pspadapter.payone.mapping.MappingUtil.getPaymentLanguage;
-import static com.commercetools.pspadapter.tenant.TenantLoggerUtil.createLoggerName;
+import static com.commercetools.pspadapter.tenant.TenantLoggerUtil.createTenantKeyValue;
 
 /**
  * @author fhaertig
@@ -38,7 +38,7 @@ public abstract class PayoneRequestFactory {
 
     protected PayoneRequestFactory(@Nonnull final TenantConfig tenantConfig) {
         this.tenantConfig = tenantConfig;
-        this.logger = LoggerFactory.getLogger(createLoggerName(this.getClass(), tenantConfig.getName()));
+        this.logger = LoggerFactory.getLogger(this.getClass());
     }
 
     @Nonnull
@@ -82,22 +82,25 @@ public abstract class PayoneRequestFactory {
         try {
             MappingUtil.mapCustomerToRequest(request, ctPayment.getCustomer());
         } catch (final IllegalArgumentException ex) {
-            logger.debug("Could not fully map customer in payment with ID {} {}",
-                    paymentWithCartLike.getPayment().getId(), ex.getMessage());
+            logger.debug(createTenantKeyValue(tenantConfig.getName()),
+                "Could not fully map customer in payment with ID {} {}",
+                paymentWithCartLike.getPayment().getId(), ex.getMessage());
         }
 
         try {
             MappingUtil.mapBillingAddressToRequest(request, ctCartLike.getBillingAddress());
         } catch (final IllegalArgumentException ex) {
-            logger.error("Could not fully map billing address in payment with ID {} {}",
-                    paymentWithCartLike.getPayment().getId(), ex.getMessage());
+            logger.error(createTenantKeyValue(tenantConfig.getName()),
+                "Could not fully map billing address in payment with ID {} {}",
+                paymentWithCartLike.getPayment().getId(), ex.getMessage());
         }
 
         try {
             MappingUtil.mapShippingAddressToRequest(request, ctCartLike.getShippingAddress());
         } catch (final IllegalArgumentException ex) {
-            logger.debug("Could not fully map shipping address in payment with ID {} {}",
-                    paymentWithCartLike.getPayment().getId(), ex.getMessage());
+            logger.debug(createTenantKeyValue(tenantConfig.getName()),
+                "Could not fully map shipping address in payment with ID {} {}",
+                paymentWithCartLike.getPayment().getId(), ex.getMessage());
         }
 
         //customer's locale, if set in custom field or cartLike

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import static com.commercetools.pspadapter.payone.mapping.MappingUtil.getGenderFromPaymentCart;
 import static com.commercetools.pspadapter.payone.mapping.MappingUtil.getPaymentLanguage;
 import static com.commercetools.pspadapter.tenant.TenantLoggerUtil.createTenantKeyValue;
+import static java.lang.String.format;
 
 /**
  * @author fhaertig
@@ -82,25 +83,31 @@ public abstract class PayoneRequestFactory {
         try {
             MappingUtil.mapCustomerToRequest(request, ctPayment.getCustomer());
         } catch (final IllegalArgumentException ex) {
-            logger.debug(createTenantKeyValue(tenantConfig.getName()),
-                "Could not fully map customer in payment with id '{}'",
-                paymentWithCartLike.getPayment().getId(), ex);
+            logger.debug(
+                createTenantKeyValue(tenantConfig.getName()),
+                format("Could not fully map customer in payment with id '%s'",
+                    paymentWithCartLike.getPayment().getId()),
+                ex);
         }
 
         try {
             MappingUtil.mapBillingAddressToRequest(request, ctCartLike.getBillingAddress());
         } catch (final IllegalArgumentException ex) {
-            logger.error(createTenantKeyValue(tenantConfig.getName()),
-                "Could not fully map billing address in payment with id '{}'",
-                paymentWithCartLike.getPayment().getId(), ex);
+            logger.error(
+                createTenantKeyValue(tenantConfig.getName()),
+                format("Could not fully map billing address in payment with id '%s'",
+                    paymentWithCartLike.getPayment().getId()),
+                ex);
         }
 
         try {
             MappingUtil.mapShippingAddressToRequest(request, ctCartLike.getShippingAddress());
         } catch (final IllegalArgumentException ex) {
-            logger.debug(createTenantKeyValue(tenantConfig.getName()),
-                "Could not fully map shipping address in payment with id '{}'",
-                paymentWithCartLike.getPayment().getId(), ex);
+            logger.debug(
+                createTenantKeyValue(tenantConfig.getName()),
+                format("Could not fully map shipping address in payment with id '%s'",
+                    paymentWithCartLike.getPayment().getId()),
+                ex);
         }
 
         //customer's locale, if set in custom field or cartLike

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
@@ -83,24 +83,24 @@ public abstract class PayoneRequestFactory {
             MappingUtil.mapCustomerToRequest(request, ctPayment.getCustomer());
         } catch (final IllegalArgumentException ex) {
             logger.debug(createTenantKeyValue(tenantConfig.getName()),
-                "Could not fully map customer in payment with ID {} {}",
-                paymentWithCartLike.getPayment().getId(), ex.getMessage());
+                "Could not fully map customer in payment with id '{}'",
+                paymentWithCartLike.getPayment().getId(), ex);
         }
 
         try {
             MappingUtil.mapBillingAddressToRequest(request, ctCartLike.getBillingAddress());
         } catch (final IllegalArgumentException ex) {
             logger.error(createTenantKeyValue(tenantConfig.getName()),
-                "Could not fully map billing address in payment with ID {} {}",
-                paymentWithCartLike.getPayment().getId(), ex.getMessage());
+                "Could not fully map billing address in payment with id '{}'",
+                paymentWithCartLike.getPayment().getId(), ex);
         }
 
         try {
             MappingUtil.mapShippingAddressToRequest(request, ctCartLike.getShippingAddress());
         } catch (final IllegalArgumentException ex) {
             logger.debug(createTenantKeyValue(tenantConfig.getName()),
-                "Could not fully map shipping address in payment with ID {} {}",
-                paymentWithCartLike.getPayment().getId(), ex.getMessage());
+                "Could not fully map shipping address in payment with id '{}'",
+                paymentWithCartLike.getPayment().getId(), ex);
         }
 
         //customer's locale, if set in custom field or cartLike

--- a/service/src/main/java/com/commercetools/pspadapter/payone/notification/NotificationProcessorBase.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/notification/NotificationProcessorBase.java
@@ -126,8 +126,8 @@ public abstract class NotificationProcessorBase implements NotificationProcessor
 
         if (newPaymentState == null && updatedPayment.getPaymentStatus() != null) {
             // TODO do we need this warning?
-            logger.warn(createTenantKeyValue(tenantConfig.getName()),
-                "Payment with id [{}] has paymentStatus [{}] which can't be mapped to Order#paymentState. "
+            logger.warn(
+                createTenantKeyValue(tenantConfig.getName()), "Payment with id [{}] has paymentStatus [{}] which can't be mapped to Order#paymentState. "
                     + "The order's state remains unchanged.", updatedPayment.getId(),
                 updatedPayment.getPaymentStatus().getInterfaceCode());
         }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/notification/NotificationProcessorBase.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/notification/NotificationProcessorBase.java
@@ -125,8 +125,10 @@ public abstract class NotificationProcessorBase implements NotificationProcessor
             .mapPaymentToOrderState(updatedPayment);
 
         if (newPaymentState == null && updatedPayment.getPaymentStatus() != null) {
-            // TODO do we need this warning?
-            logger.warn(
+            // According to the following doc:
+            // https://github.com/commercetools/commercetools-payone-integration/blob/master/docs/Order-Payment-Status-Mapping.md
+            // in come cases we leave the state unchanged.
+            logger.debug(
                 createTenantKeyValue(tenantConfig.getName()), "Payment with id [{}] has paymentStatus [{}] which can't be mapped to Order#paymentState. "
                     + "The order's state remains unchanged.", updatedPayment.getId(),
                 updatedPayment.getPaymentStatus().getInterfaceCode());

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
@@ -158,7 +158,7 @@ abstract class BaseBankTransferInAdvanceTransactionExecutor extends TransactionB
             }
 
             // TODO: https://github.com/commercetools/commercetools-payone-integration/issues/199
-            throw new IllegalStateException("Unknown PayOne status: " + status);
+            throw new IllegalStateException("Unknown Payone status: " + status);
         } catch (PayoneException paymentException) {
             LOGGER.error(format("Request to Payone failed for commercetools Payment with id '%s' and "
                     + "Transaction with id '%s'.", paymentWithCartLike.getPayment().getId(), transactionId),

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.*;
+import static java.lang.String.format;
 
 /**
  * Responsible to create the PayOne Request (PreAuthorization) and check if answer is approved or Error
@@ -158,11 +159,14 @@ abstract class BaseBankTransferInAdvanceTransactionExecutor extends TransactionB
 
             // TODO: https://github.com/commercetools/commercetools-payone-integration/issues/199
             throw new IllegalStateException("Unknown PayOne status: " + status);
-        } catch (PayoneException pe) {
-            LOGGER.error("Payone request exception: ", pe);
+        } catch (PayoneException paymentException) {
+            LOGGER.error(format("Request to Payone failed for commercetools Payment with id '%s' and "
+                    + "Transaction with id '%s'.", paymentWithCartLike.getPayment().getId(), transactionId),
+                paymentException);
+
 
             final AddInterfaceInteraction interfaceInteraction = AddInterfaceInteraction.ofTypeKeyAndObjects(CustomTypeBuilder.PAYONE_INTERACTION_RESPONSE,
-                    ImmutableMap.of(CustomFieldKeys.RESPONSE_FIELD, exceptionToResponseJsonString(pe),
+                    ImmutableMap.of(CustomFieldKeys.RESPONSE_FIELD, exceptionToResponseJsonString(paymentException),
                             CustomFieldKeys.TRANSACTION_ID_FIELD, transactionId,
                             CustomFieldKeys.TIMESTAMP_FIELD, ZonedDateTime.now()));
 

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantLoggerUtil.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantLoggerUtil.java
@@ -1,26 +1,20 @@
 package com.commercetools.pspadapter.tenant;
 
+import net.logstash.logback.marker.LogstashMarker;
+
 import javax.annotation.Nonnull;
 
-import static java.lang.String.format;
+import static net.logstash.logback.marker.Markers.append;
 
 public final class TenantLoggerUtil {
 
     /**
-     * Opposite to logger name generated in {@link #createLoggerName(Class, String)}
-     * this one is used in static common loggers where it is not possible to generate separate tenant loggers.
+     * Create a LogStashMarker with name which consists of the tenant name.
+     * @param tenantName tenant name to append to the logger.
+     * @return a LogStashMarker with name which consists of the tenant name.
      */
-    public static final String LOG_PREFIX = "[tenant {}]";
-
-    /**
-     * Create a logger with name which consists of full qualified {@code clazz} name
-     * and the suffix "[tenant &lt;name&gt;]".
-     * @param clazz Class where the logger is used
-     * @param tenantName tenant name to attach to the class name.
-     * @return Concatenated FQDN and the {@code tenantName} wrapped to "[tenant &lt;name&gt;]" construction.
-     */
-    public static String createLoggerName(@Nonnull Class clazz, @Nonnull String tenantName) {
-        return format("%s[tenant %s]", clazz.getName(), tenantName);
+    public static LogstashMarker createTenantKeyValue(@Nonnull final String tenantName) {
+        return append("tenantName", tenantName);
     }
 
     private TenantLoggerUtil() {

--- a/service/src/test/java/com/commercetools/pspadapter/payone/PaymentHandlerTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/PaymentHandlerTest.java
@@ -204,7 +204,7 @@ public class PaymentHandlerTest
 
         // assert
         assertThat(paymentHandleResult.statusCode()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
-        assertThat(paymentHandleResult.body()).contains(format("An error occurred during communication with the commercetools platform when processing [%s] payment. See the service logs", paymentId));
+        assertThat(paymentHandleResult.body()).contains(format("Unexpected error occurred when processing commercetools Payment with id [%s]. See the service logs", paymentId));
     }
 
     @Test

--- a/service/src/test/java/com/commercetools/pspadapter/payone/PaymentHandlerTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/PaymentHandlerTest.java
@@ -4,9 +4,11 @@ import com.commercetools.pspadapter.payone.domain.ctp.CommercetoolsQueryExecutor
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.ctp.exceptions.NoCartLikeFoundException;
 import io.sphere.sdk.carts.Cart;
+import io.sphere.sdk.client.ErrorResponseException;
 import io.sphere.sdk.client.NotFoundException;
 import io.sphere.sdk.http.HttpStatusCode;
 import io.sphere.sdk.json.SphereJsonUtils;
+import io.sphere.sdk.models.errors.ErrorResponse;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentMethodInfo;
 import io.sphere.sdk.types.CustomFields;
@@ -17,14 +19,13 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.io.IOException;
 import java.util.ConcurrentModificationException;
 import java.util.Random;
 import java.util.concurrent.CompletionException;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
@@ -44,9 +45,6 @@ public class PaymentHandlerTest
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
-//    @Mock
-//    private CustomTypeBuilder customTypeBuilder;
-
     @Mock
     private CommercetoolsQueryExecutor commercetoolsQueryExecutor;
 
@@ -59,7 +57,7 @@ public class PaymentHandlerTest
     private PaymentHandler testee;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
         // the last argument in the constructor is a String, that's why we can't use @InjectMocks for this instantiation
         testee = new PaymentHandler("TestIntegrationServicePaymentMethodName", "testTenantName", commercetoolsQueryExecutor, paymentDispatcher);
 
@@ -88,7 +86,7 @@ public class PaymentHandlerTest
 
     @Test
     @SuppressWarnings("unchecked")
-    public void returnsStatusCodeOk200InCaseOfSuccessfulConcurrentPaymentHandling() throws IOException {
+    public void returnsStatusCodeOk200InCaseOfSuccessfulConcurrentPaymentHandling() {
         // arrange
         final String paymentId = randomString();
         final PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, UNUSED_CART);
@@ -117,7 +115,7 @@ public class PaymentHandlerTest
 
     @Test
     @SuppressWarnings("unchecked")
-    public void returnsStatusCodeAccepted202InCaseOfOngoingConcurrentPaymentHandling() {
+    public void handlePayment_WithAlwaysConcurrentModificationException_ShouldReturn202() {
         // arrange
         final String paymentId = randomString();
         final PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, UNUSED_CART);
@@ -132,7 +130,77 @@ public class PaymentHandlerTest
 
         // assert
         assertThat(paymentHandleResult.statusCode()).isEqualTo(HttpStatusCode.ACCEPTED_202);
-        assertThat(paymentHandleResult.body()).contains("The payment couldn't be processed");
+        assertThat(paymentHandleResult.body())
+            .isEqualTo(format("The payment with id '%s' couldn't be processed after %s retries.", paymentId, 20));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void handlePayment_WithLessThanLimitConcurrentModificationException_ShouldReturn200() {
+        // arrange
+        final String paymentId = randomString();
+        final PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, UNUSED_CART);
+
+        when(paymentDispatcher.dispatchPayment(same(paymentWithCartLike)))
+            .thenThrow(ConcurrentModificationException.class)
+            .thenThrow(ConcurrentModificationException.class)
+            .thenReturn(new PaymentWithCartLike(payment, UNUSED_CART));
+
+        when(commercetoolsQueryExecutor.getPaymentWithCartLike(eq(paymentId))).thenReturn(paymentWithCartLike);
+
+        // act
+        final PaymentHandleResult paymentHandleResult = testee.handlePayment(paymentId);
+
+        // assert
+        assertThat(paymentHandleResult.statusCode()).isEqualTo(HttpStatusCode.OK_200);
+        assertThat(paymentHandleResult.body()).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void handlePayment_WithLessThanLimitConcurrentModificationExceptionButNotFound_ShouldReturn404() {
+        // arrange
+        final String paymentId = randomString();
+        final PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, UNUSED_CART);
+
+        when(paymentDispatcher.dispatchPayment(same(paymentWithCartLike)))
+            .thenThrow(ConcurrentModificationException.class)
+            .thenThrow(ConcurrentModificationException.class)
+            .thenThrow(new NotFoundException());
+
+        when(commercetoolsQueryExecutor.getPaymentWithCartLike(eq(paymentId))).thenReturn(paymentWithCartLike);
+
+        // act
+        final PaymentHandleResult paymentHandleResult = testee.handlePayment(paymentId);
+
+        // assert
+        assertThat(paymentHandleResult.statusCode()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        assertThat(paymentHandleResult.body()).contains(format("Failed to process the commercetools Payment with id "
+            + "[%s], as the payment or the cart could not be found", paymentId));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void handlePayment_WithLessThanLimitConcurrentModificationExceptionErrorResponseException_ShouldReturn502() {
+        // arrange
+        final String paymentId = randomString();
+        final PaymentWithCartLike paymentWithCartLike = new PaymentWithCartLike(payment, UNUSED_CART);
+
+        when(paymentDispatcher.dispatchPayment(same(paymentWithCartLike)))
+            .thenThrow(ConcurrentModificationException.class)
+            .thenThrow(ConcurrentModificationException.class)
+            .thenThrow(new ErrorResponseException(ErrorResponse.of(HttpStatusCode.BAD_GATEWAY_502,
+                "commercetools is unavailable", emptyList())));
+
+        when(commercetoolsQueryExecutor.getPaymentWithCartLike(eq(paymentId))).thenReturn(paymentWithCartLike);
+
+        // act
+        final PaymentHandleResult paymentHandleResult = testee.handlePayment(paymentId);
+
+        // assert
+        assertThat(paymentHandleResult.statusCode()).isEqualTo(HttpStatusCode.BAD_GATEWAY_502);
+        assertThat(paymentHandleResult.body()).contains(format("Failed to process the commercetools Payment with id "
+            + "[%s], due to an error response from the commercetools platform. Try again later.", paymentId));
     }
 
     @Test
@@ -186,7 +254,11 @@ public class PaymentHandlerTest
 
         // assert
         assertThat(paymentHandleResult.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
-        assertThat(paymentHandleResult.body()).isEmpty();
+        assertThat(paymentHandleResult.body()).contains(format("Wrong payment interface name: expected '%s', found '%s'"
+                + " for the commercetools Payment with id '%s'.",
+            payonePaymentMethodInfo.getPaymentInterface(),
+            paymentMethodInfo.getPaymentInterface(),
+            paymentId));
     }
 
     @Test
@@ -255,7 +327,7 @@ public class PaymentHandlerTest
                 PaymentMethodInfo.class);
     }
 
-    private static CustomFields customFields(final String referenceValue) throws IOException {
+    private static CustomFields customFields(final String referenceValue) {
         return SphereJsonUtils.readObject(
                 "{\n" +
                         "        \"type\": {\n" +

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/BaseTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/BaseTransaction_attemptExecutionTest.java
@@ -191,7 +191,7 @@ public class BaseTransaction_attemptExecutionTest {
 
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> executor.attemptExecution(paymentWithCartLike, transaction))
-                .withMessageContaining("Unknown PayOne status");
+                .withMessageContaining("Unknown Payone status");
 
         assertRequestInterfaceInteraction(1);
     }

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
@@ -107,7 +107,7 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
 
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> executor.attemptExecution(paymentWithCartLike, transaction))
-                .withMessageContaining("Unknown PayOne status");
+                .withMessageContaining("Unknown Payone status");
 
         assertRequestInterfaceInteraction(1);
     }


### PR DESCRIPTION
 - Remove redundant logs
- Use tenant name as marker instead of logger name.
- Always add the exception, if there is, in the log stack trace.