### PR TITLE
Update dependabot config to avoid build failure

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,6 +9,6 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "org.mockito:mockito-core"
-          version_requirement: "3.x"
+          version_requirement: "2.x"
       - match:
           dependency_name: "org.ajoberstar:gradle-git-publish"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,3 +6,9 @@ update_configs:
     automerged_updates:
       - match:
           dependency_name: "*"
+    ignored_updates:
+      - match:
+          dependency_name: "org.mockito:mockito-core"
+          version_requirement: "3.x"
+      - match:
+          dependency_name: "org.ajoberstar:gradle-git-publish"


### PR DESCRIPTION
Due to stuck Dependabot in pull requests, .dependabot/config.yml has been changed in order to avoid performing version update for some specific dependencies :
- mockito-core updates to 2.x.x in maximum.
- gradle-git-publish keeps the version unchanged.