### PR TITLE
Add decorator

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -167,9 +167,9 @@ public class TenantFactory {
     @Nonnull
     protected BlockingSphereClient createBlockingSphereClient(TenantConfig tenantConfig) {
         SphereClient sphereClient = SphereClientFactory.of().createClient(tenantConfig.getSphereClientConfig());
-        SphereClient delegateWithLimitedParallelReq =
+        SphereClient sphereClientWithLimitedParallelReq =
                 QueueSphereClientDecorator.of(sphereClient, MAX_PARALLEL_REQUESTS);
-        return BlockingSphereClient.of(delegateWithLimitedParallelReq, DEFAULT_CTP_CLIENT_TIMEOUT);
+        return BlockingSphereClient.of(sphereClientWithLimitedParallelReq, DEFAULT_CTP_CLIENT_TIMEOUT);
     }
 
     public BlockingSphereClient getBlockingSphereClient() {

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -166,11 +166,12 @@ public class TenantFactory {
 
     @Nonnull
     protected BlockingSphereClient createBlockingSphereClient(TenantConfig tenantConfig) {
-        SphereClient delegate = SphereClientFactory.of().createClient(tenantConfig.getSphereClientConfig());
-        SphereClient delegateWithLimitedParallelReq = QueueSphereClientDecorator.of(delegate, MAX_PARALLEL_REQUESTS);
+        SphereClient sphereClient = SphereClientFactory.of().createClient(tenantConfig.getSphereClientConfig());
+        SphereClient delegateWithLimitedParallelReq =
+                QueueSphereClientDecorator.of(sphereClient, MAX_PARALLEL_REQUESTS);
         return BlockingSphereClient.of(delegateWithLimitedParallelReq, DEFAULT_CTP_CLIENT_TIMEOUT);
     }
-    
+
     public BlockingSphereClient getBlockingSphereClient() {
         return blockingSphereClient;
     }

--- a/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereClientConfig;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentMethodInfoBuilder;

--- a/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
@@ -284,6 +284,13 @@ public class TenantFactoryTest {
         assertThat(paymentDispatcher).isNotNull();
     }
 
+    @Test
+    public void createBlockingSphereClient() throws Exception {
+        SphereClient client = factory.createBlockingSphereClient(tenantConfig);
+        assertThat(client).isNotNull();
+        assertThat(BlockingSphereClient.class.isInstance(client)).isTrue();
+    }
+
     /**
      * Because {@link TenantFactory} initializes {@link com.commercetools.pspadapter.payone.PaymentHandler}
      * and {@link PaymentDispatcher} inside constructor, we can't easily mock an instance, thus we make this anonymous


### PR DESCRIPTION
Apply QueueSphereClientDecorator for CTP client to limit concurrent request count. When number of request exceeds the limit threshold, incoming requests await in queue until number of processing request is less than the limit.