### PR TITLE
Add retry decorator v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ project(":service") {
         testImplementation "junit:junit:${depVersions.jUnit}"
         testImplementation "org.assertj:assertj-core:${depVersions.assertJ}"
         testImplementation "org.mockito:mockito-core:${depVersions.mockito}"
+        testImplementation "org.mockito:mockito-inline:${depVersions.mockito}"
     }
 
     shadowJar {

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -30,6 +30,7 @@ import com.commercetools.service.OrderService;
 import com.commercetools.service.OrderServiceImpl;
 import com.commercetools.service.PaymentService;
 import com.commercetools.service.PaymentServiceImpl;
+import com.commercetools.util.SphereClientConfigurationUtil;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
@@ -166,10 +167,7 @@ public class TenantFactory {
 
     @Nonnull
     protected BlockingSphereClient createBlockingSphereClient(TenantConfig tenantConfig) {
-        SphereClient sphereClient = SphereClientFactory.of().createClient(tenantConfig.getSphereClientConfig());
-        SphereClient sphereClientWithLimitedParallelReq =
-                QueueSphereClientDecorator.of(sphereClient, MAX_PARALLEL_REQUESTS);
-        return BlockingSphereClient.of(sphereClientWithLimitedParallelReq, DEFAULT_CTP_CLIENT_TIMEOUT);
+        return SphereClientConfigurationUtil.createClient(tenantConfig.getSphereClientConfig());
     }
 
     public BlockingSphereClient getBlockingSphereClient() {

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -51,10 +51,6 @@ import static java.lang.String.format;
 
 public class TenantFactory {
 
-    private static final Duration DEFAULT_CTP_CLIENT_TIMEOUT = Duration.ofSeconds(10);
-
-    private static final int MAX_PARALLEL_REQUESTS = 30;
-
     private final String payoneInterfaceName;
 
     private final String tenantName;

--- a/service/src/main/java/com/commercetools/util/SphereClientConfigurationUtil.java
+++ b/service/src/main/java/com/commercetools/util/SphereClientConfigurationUtil.java
@@ -65,7 +65,7 @@ public final class SphereClientConfigurationUtil {
         return RetrySphereClientDecorator.of(sphereClient, retryRules);
     }
 
-    private static BlockingSphereClient withBlocking(final SphereClient sphereClient) {
+    private static BlockingSphereClient withBlocking(@Nonnull final SphereClient sphereClient) {
         return BlockingSphereClient.of(sphereClient, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_TIME_UNIT);
     }
 
@@ -83,7 +83,7 @@ public final class SphereClientConfigurationUtil {
         return new Random().longs(min, (max + 1)).limit(1).findFirst().getAsLong();
     }
 
-    private static SphereClient withLimitedParallelRequests(final SphereClient sphereClient) {
+    private static SphereClient withLimitedParallelRequests(@Nonnull final SphereClient sphereClient) {
         return QueueSphereClientDecorator.of(sphereClient, MAX_PARALLEL_REQUESTS);
     }
 

--- a/service/src/main/java/com/commercetools/util/SphereClientConfigurationUtil.java
+++ b/service/src/main/java/com/commercetools/util/SphereClientConfigurationUtil.java
@@ -1,0 +1,91 @@
+package com.commercetools.util;
+
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.client.QueueSphereClientDecorator;
+import io.sphere.sdk.client.RetrySphereClientDecorator;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.client.SphereClientConfig;
+import io.sphere.sdk.client.SphereClientFactory;
+import io.sphere.sdk.retry.RetryAction;
+import io.sphere.sdk.retry.RetryPredicate;
+import io.sphere.sdk.retry.RetryRule;
+
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.sphere.sdk.http.HttpStatusCode.BAD_GATEWAY_502;
+import static io.sphere.sdk.http.HttpStatusCode.GATEWAY_TIMEOUT_504;
+import static io.sphere.sdk.http.HttpStatusCode.SERVICE_UNAVAILABLE_503;
+
+public final class SphereClientConfigurationUtil {
+    private static final long DEFAULT_TIMEOUT = 10;
+    private static final TimeUnit DEFAULT_TIMEOUT_TIME_UNIT = TimeUnit.SECONDS;
+    protected static final int RETRIES_LIMIT = 5;
+    private static final int MAX_PARALLEL_REQUESTS = 30;
+    private static final long DEFAULT_RETRY_INTERVAL_IN_SECOND = 10;
+
+    /**
+     * Creates a {@link BlockingSphereClient} with a custom {@code timeout} with a custom {@link
+     * TimeUnit} as waiting time limit for blocking SphereClient to complete CTP request .
+     *
+     * @param clientConfig the client configuration for the client.
+     * @return the instantiated {@link BlockingSphereClient}.
+     */
+    public static BlockingSphereClient createClient(@Nonnull final SphereClientConfig clientConfig) {
+        final SphereClient underlyingClient = SphereClientFactory.of().createClient(clientConfig);
+        return decorateSphereClient(underlyingClient);
+    }
+
+    /**
+     * Creates a {@link BlockingSphereClient} with a custom {@code timeout} with a custom {@link
+     * TimeUnit} as waiting time limit for blocking SphereClient to complete CTP request .
+     *
+     * @param sphereClient the HTTP underlying client.
+     * @return the instantiated {@link BlockingSphereClient}.
+     */
+    protected static BlockingSphereClient decorateSphereClient(@Nonnull final SphereClient sphereClient) {
+        final SphereClient retryClient = withRetry(sphereClient);
+        final SphereClient limitedClient = withLimitedParallelRequests(retryClient);
+        return withBlocking(limitedClient);
+    }
+
+    private static SphereClient withRetry(@Nonnull final SphereClient sphereClient) {
+        final RetryAction scheduledRetry =
+                RetryAction.ofScheduledRetry(RETRIES_LIMIT, context -> calculateVariableDelay());
+        final RetryPredicate http5xxMatcher =
+                RetryPredicate.ofMatchingStatusCodes(
+                        BAD_GATEWAY_502, SERVICE_UNAVAILABLE_503, GATEWAY_TIMEOUT_504);
+        final List<RetryRule> retryRules =
+                Collections.singletonList(RetryRule.of(http5xxMatcher, scheduledRetry));
+        return RetrySphereClientDecorator.of(sphereClient, retryRules);
+    }
+
+    private static BlockingSphereClient withBlocking(final SphereClient sphereClient) {
+        return BlockingSphereClient.of(sphereClient, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_TIME_UNIT);
+    }
+
+    /**
+     * Computes a variable delay in seconds.
+     *
+     * @return a computed variable delay in seconds, which is a random component in addition to a default interval.
+     */
+    private static Duration calculateVariableDelay() {
+        final long randomNumberInRange = getRandomNumberInRange(1, DEFAULT_RETRY_INTERVAL_IN_SECOND);
+        return Duration.ofSeconds(DEFAULT_RETRY_INTERVAL_IN_SECOND + randomNumberInRange);
+    }
+
+    private static long getRandomNumberInRange(final long min, final long max) {
+        return new Random().longs(min, (max + 1)).limit(1).findFirst().getAsLong();
+    }
+
+    private static SphereClient withLimitedParallelRequests(final SphereClient sphereClient) {
+        return QueueSphereClientDecorator.of(sphereClient, MAX_PARALLEL_REQUESTS);
+    }
+
+    private SphereClientConfigurationUtil() {}
+}

--- a/service/src/test/java/com/commercetools/util/SphereClientConfigurationUtilTest.java
+++ b/service/src/test/java/com/commercetools/util/SphereClientConfigurationUtilTest.java
@@ -1,0 +1,84 @@
+package com.commercetools.util;
+
+import com.commercetools.pspadapter.tenant.TenantConfig;
+
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.client.SphereClientConfig;
+import io.sphere.sdk.client.TestDoubleSphereClientFactory;
+import io.sphere.sdk.http.HttpResponse;
+import io.sphere.sdk.http.HttpStatusCode;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQueryBuilder;
+import java.util.concurrent.CompletionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SphereClientConfigurationUtilTest {
+
+    @Mock
+    private TenantConfig tenantConfig;
+
+    @Before
+    public void setUp() throws Exception {
+        when(tenantConfig.getSphereClientConfig())
+                .thenReturn(SphereClientConfig.of("test-key", "test-client-id", "test-client-secret"));
+    }
+
+    @Test
+    public void executeCreateClient_isBlocking() {
+        SphereClient sphereClient = SphereClientConfigurationUtil.createClient(tenantConfig.getSphereClientConfig());
+        assertThat(sphereClient instanceof BlockingSphereClient).isTrue();
+    }
+
+    @Test
+    public void decorateClient_shouldRetry_when5xxHttpResponse() {
+        SphereClient mockSphereUnderlyingClient =
+                spy(TestDoubleSphereClientFactory.createHttpTestDouble(
+                        intent -> HttpResponse.of(HttpStatusCode.BAD_GATEWAY_502)));
+
+        final BlockingSphereClient blockingSphereClient =
+                SphereClientConfigurationUtil.decorateSphereClient(mockSphereUnderlyingClient);
+
+        final TaxCategoryQuery query = TaxCategoryQueryBuilder.of().build();
+        try {
+            blockingSphereClient.execute(query).toCompletableFuture().join();
+        } catch (CompletionException e) {
+            // Skipped
+        }
+        verify(mockSphereUnderlyingClient,
+                times(SphereClientConfigurationUtil.RETRIES_LIMIT+1))
+                .execute(query);
+    }
+
+
+    @Test
+    public void decorateClient_shouldNotRetry_when4xxHttpResponse() {
+        SphereClient mockSphereUnderlyingClient =
+                spy(TestDoubleSphereClientFactory.createHttpTestDouble(
+                        intent -> HttpResponse.of(HttpStatusCode.BAD_REQUEST_400)));
+
+        final BlockingSphereClient blockingSphereClient =
+                SphereClientConfigurationUtil.decorateSphereClient(mockSphereUnderlyingClient);
+
+        final TaxCategoryQuery query = TaxCategoryQueryBuilder.of().build();
+        try {
+            blockingSphereClient.execute(query).toCompletableFuture().join();
+        } catch (CompletionException e) {
+            // Skipped
+        }
+        verify(mockSphereUnderlyingClient,
+                times(1))
+                .execute(query);
+    }
+}


### PR DESCRIPTION
RetrySphereClientDecorator is needed for recoverable errors on the payment service, as well as the request to CTP.

This is a newly created PR. The previous PR can be found here
#301 

It is because other fix for functional tests has been applied on master branch in these days. Featured branch has to be forked from master branch again to pass functional tests.