### PR TITLE
CAR-3312: reduce payone HTTP timeout from 8 sec to 5 sec

### DIFF
--- a/service/src/main/java/com/commercetools/util/PayoneHttpClientUtil.java
+++ b/service/src/main/java/com/commercetools/util/PayoneHttpClientUtil.java
@@ -36,7 +36,7 @@ public final class PayoneHttpClientUtil {
 
     public static final int TIMEOUT_WHEN_CONNECTION_POOL_FULLY_OCCUPIED = 10000;
 
-    public static final int TIMEOUT_WHEN_CONTINUOUS_DATA_STREAM_DOES_NOT_REPLY = 8000;
+    public static final int TIMEOUT_WHEN_CONTINUOUS_DATA_STREAM_DOES_NOT_REPLY = 5000;
 
     static final int RETRY_TIMES = 5;
 


### PR DESCRIPTION
## Description

Decreased the HTTP timeout value for payone HTTP client. New timeout is 5 seconds.