### PR TITLE
remove retry logic which were related to quartz jobs

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/BaseDefaultTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/BaseDefaultTransactionExecutor.java
@@ -17,14 +17,15 @@ import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.Transaction;
 import io.sphere.sdk.payments.TransactionState;
 import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
-import io.sphere.sdk.payments.commands.updateactions.*;
-import io.sphere.sdk.types.CustomFields;
+import io.sphere.sdk.payments.commands.updateactions.AddInterfaceInteraction;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionInteractionId;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
 import io.sphere.sdk.types.Type;
 import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -79,33 +80,9 @@ abstract public class BaseDefaultTransactionExecutor extends TransactionBaseExec
     }
 
     @Override
-    protected Optional<CustomFields> findLastExecutionAttempt(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
-        return getCustomFieldsOfType(paymentWithCartLike, CustomTypeBuilder.PAYONE_INTERACTION_REQUEST)
-                .filter(i -> transaction.getId().equals(i.getFieldAsString(CustomFieldKeys.TRANSACTION_ID_FIELD)))
-                .reduce((previous, current) -> current); // .findLast()
-    }
-
-    @Override
     @Nonnull
-    protected PaymentWithCartLike retryLastExecutionAttempt(@Nonnull PaymentWithCartLike paymentWithCartLike,
-                                                            @Nonnull Transaction transaction,
-                                                            @Nonnull CustomFields lastExecutionAttempt) {
-        ZonedDateTime fieldAsDateTime = lastExecutionAttempt.getFieldAsDateTime(CustomFieldKeys.TIMESTAMP_FIELD);
-        if (fieldAsDateTime == null || fieldAsDateTime.isBefore(ZonedDateTime.now().minusMinutes(5))) {
-            return attemptExecution(paymentWithCartLike, transaction);
-        } else {
-            if (fieldAsDateTime.isAfter(ZonedDateTime.now().minusMinutes(1)))
-                throw new ConcurrentModificationException(format(
-                        "A processing of payment with ID \"%s\" started during the last 60 seconds and is likely to be finished soon, no need to retry now.",
-                        paymentWithCartLike.getPayment().getId()));
-        }
-        return paymentWithCartLike;
-    }
-
-    @Override
-    @Nonnull
-    protected PaymentWithCartLike attemptExecution(final PaymentWithCartLike paymentWithCartLike,
-                                                   final Transaction transaction) {
+    protected PaymentWithCartLike execute(final PaymentWithCartLike paymentWithCartLike,
+                                          final Transaction transaction) {
         final String transactionId = transaction.getId();
         final String sequenceNumber = String.valueOf(getNextSequenceNumber(paymentWithCartLike));
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutor.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -55,9 +54,7 @@ public abstract class IdempotentTransactionExecutor implements TransactionExecut
             return paymentWithCartLike;
         }
 
-        return findLastExecutionAttempt(paymentWithCartLike, transaction)
-                .map(attempt -> retryLastExecutionAttempt(paymentWithCartLike, transaction, attempt))
-                .orElseGet(() -> attemptFirstExecution(paymentWithCartLike, transaction));
+        return executeIdempotent(paymentWithCartLike, transaction);
     }
 
     /**
@@ -77,29 +74,7 @@ public abstract class IdempotentTransactionExecutor implements TransactionExecut
      * @param transaction
      * @return A new version of the PaymentWithCartLike. If the attempt has concluded, the state of the Transaction is now either Success or Failure.
      */
-    protected abstract PaymentWithCartLike attemptFirstExecution(PaymentWithCartLike paymentWithCartLike, Transaction transaction);
-
-    /**
-     * Finds a previous execution attempt for the transaction. If there are multiple ones, it selects the last one.
-     *
-     * @param paymentWithCartLike
-     * @param transaction
-     * @return An attempt, or Optional.empty if there was no previous attempt
-     */
-    protected abstract Optional<CustomFields> findLastExecutionAttempt(PaymentWithCartLike paymentWithCartLike, Transaction transaction);
-
-    /**
-     * Retries the last execution attempt for the transaction. It does take necessary precautions for idempotency.
-     *
-     * @param paymentWithCartLike
-     * @param transaction
-     * @param lastExecutionAttempt
-     * @return A new version of the PaymentWithCartLike.
-     */
-    @Nonnull
-    protected abstract PaymentWithCartLike retryLastExecutionAttempt(@Nonnull PaymentWithCartLike paymentWithCartLike,
-                                                                     @Nonnull Transaction transaction,
-                                                                     @Nonnull CustomFields lastExecutionAttempt);
+    protected abstract PaymentWithCartLike executeIdempotent(PaymentWithCartLike paymentWithCartLike, Transaction transaction);
 
     /**
      * Determines the next sequence number to use from already received notifications.

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/TransactionBaseExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/TransactionBaseExecutor.java
@@ -16,7 +16,13 @@ import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.Transaction;
 import io.sphere.sdk.payments.TransactionState;
 import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
-import io.sphere.sdk.payments.commands.updateactions.*;
+import io.sphere.sdk.payments.commands.updateactions.AddInterfaceInteraction;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionTimestamp;
+import io.sphere.sdk.payments.commands.updateactions.SetCustomField;
+import io.sphere.sdk.payments.commands.updateactions.SetInterfaceId;
+import io.sphere.sdk.payments.commands.updateactions.SetStatusInterfaceCode;
+import io.sphere.sdk.payments.commands.updateactions.SetStatusInterfaceText;
 import io.sphere.sdk.types.Type;
 
 import javax.annotation.Nonnull;
@@ -25,7 +31,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.*;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.CUSTOMER_MESSAGE;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.ERROR_CODE;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.ERROR_MESSAGE;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.STATUS;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.TXID;
 import static com.commercetools.pspadapter.payone.util.PaymentUtil.getTransactionById;
 
 /**
@@ -45,13 +55,13 @@ public abstract class TransactionBaseExecutor extends IdempotentTransactionExecu
     }
 
     @Override
-    protected PaymentWithCartLike attemptFirstExecution(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
-        return attemptExecution(paymentWithCartLike, transaction);
+    protected PaymentWithCartLike executeIdempotent(PaymentWithCartLike paymentWithCartLike, Transaction transaction) {
+        return execute(paymentWithCartLike, transaction);
     }
 
     @Nonnull
-    abstract protected PaymentWithCartLike attemptExecution(final PaymentWithCartLike paymentWithCartLike,
-                                                            final Transaction transaction);
+    abstract protected PaymentWithCartLike execute(final PaymentWithCartLike paymentWithCartLike,
+                                                   final Transaction transaction);
 
     /**
      * Creates the SetStatusInterfaceCode from the response

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/BaseTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/BaseTransaction_attemptExecutionTest.java
@@ -106,7 +106,7 @@ public class BaseTransaction_attemptExecutionTest {
                 PayoneResponseFields.REDIRECT_URL, "http://mock-redirect.url",
                 PayoneResponseFields.TXID, "responseTxid"
         ));
-        executor.attemptExecution(paymentWithCartLike, transaction);
+        executor.execute(paymentWithCartLike, transaction);
 
         assertRequestInterfaceInteraction(2);
         assertRedirectActions(TransactionState.PENDING);
@@ -121,7 +121,7 @@ public class BaseTransaction_attemptExecutionTest {
                 PayoneResponseFields.STATUS, APPROVED.getStateCode(),
                 PayoneResponseFields.TXID, "responseTxid"
         ));
-        executor.attemptExecution(paymentWithCartLike, transaction);
+        executor.execute(paymentWithCartLike, transaction);
 
         assertRequestInterfaceInteraction(2);
         assertChangeTransactionStateActions(TransactionState.SUCCESS);
@@ -138,7 +138,7 @@ public class BaseTransaction_attemptExecutionTest {
                 PayoneResponseFields.STATUS, ERROR.getStateCode(),
                 PayoneResponseFields.TXID, "responseTxid"
         ));
-        executor.attemptExecution(paymentWithCartLike, transaction);
+        executor.execute(paymentWithCartLike, transaction);
 
         assertRequestInterfaceInteraction(2);
         assertChangeTransactionStateActions(TransactionState.FAILURE);
@@ -154,7 +154,7 @@ public class BaseTransaction_attemptExecutionTest {
                 PayoneResponseFields.STATUS, PENDING.getStateCode(),
                 PayoneResponseFields.TXID, "responseTxid"
         ));
-        executor.attemptExecution(paymentWithCartLike, transaction);
+        executor.execute(paymentWithCartLike, transaction);
 
         assertRequestInterfaceInteraction(2);
         assertChangeTransactionStateActions(TransactionState.PENDING);
@@ -169,7 +169,7 @@ public class BaseTransaction_attemptExecutionTest {
                                                                              final TransactionBaseExecutor executor) throws Exception {
         when(payonePostService.executePost(request)).thenThrow(new PayoneException("payone exception message"));
 
-        executor.attemptExecution(paymentWithCartLike, transaction);
+        executor.execute(paymentWithCartLike, transaction);
 
         assertRequestInterfaceInteraction(2);
         assertChangeTransactionStateActions(TransactionState.FAILURE);
@@ -190,7 +190,7 @@ public class BaseTransaction_attemptExecutionTest {
         ));
 
         assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> executor.attemptExecution(paymentWithCartLike, transaction))
+                .isThrownBy(() -> executor.execute(paymentWithCartLike, transaction))
                 .withMessageContaining("Unknown Payone status");
 
         assertRequestInterfaceInteraction(1);

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutorTest.java
@@ -125,21 +125,8 @@ public class IdempotentTransactionExecutorTest {
         }
 
         @Override
-        protected PaymentWithCartLike attemptFirstExecution(final PaymentWithCartLike paymentWithCartLike, final Transaction transaction) {
+        protected PaymentWithCartLike executeIdempotent(final PaymentWithCartLike paymentWithCartLike, final Transaction transaction) {
             return null;
-        }
-
-        @Override
-        protected Optional<CustomFields> findLastExecutionAttempt(final PaymentWithCartLike paymentWithCartLike, final Transaction transaction) {
-            return null;
-        }
-
-        @Override
-        @Nonnull
-        protected PaymentWithCartLike retryLastExecutionAttempt(@Nonnull final PaymentWithCartLike paymentWithCartLike,
-                                                                @Nonnull final Transaction transaction,
-                                                                @Nonnull final CustomFields lastExecutionAttempt) {
-            return mock(PaymentWithCartLike.class);
         }
     }
 

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransaction_attemptExecutionTest.java
@@ -54,7 +54,7 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
                 PayoneResponseFields.IBAN, "test-mock-IBAN",
                 PayoneResponseFields.ACCOUNT_HOLDER, "test-mock-NAME"
         ));
-        executor.attemptExecution(paymentWithCartLike, transaction);
+        executor.execute(paymentWithCartLike, transaction);
 
         assertRequestInterfaceInteraction(2);
 
@@ -106,7 +106,7 @@ public class BankTransferInAdvanceChargeTransaction_attemptExecutionTest extends
         ));
 
         assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> executor.attemptExecution(paymentWithCartLike, transaction))
+                .isThrownBy(() -> executor.execute(paymentWithCartLike, transaction))
                 .withMessageContaining("Unknown Payone status");
 
         assertRequestInterfaceInteraction(1);


### PR DESCRIPTION
## Description

- We have already removed Quartz cronjobs within the library in the past. https://github.com/commercetools/commercetools-payone-integration/pull/226
- But we had mistakenly left some of the related logic in the payment request processing workflows. This pr have removed those logics.