### PR TITLE
Replace guavas caching library with caffeine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ def depVersions = [
         sparkCore: '2.9.3',
         jUnit: '4.13.1',
         assertJ: '3.19.0',
-        mockito: '3.9.0'
+        mockito: '3.9.0',
+        caffeine: '2.9.0'
 ]
 
 subprojects {
@@ -55,6 +56,7 @@ subprojects {
 
     dependencies {
         implementation "com.google.guava:guava:${depVersions.guava}"
+        implementation "com.github.ben-manes.caffeine:caffeine:${depVersions.caffeine}"
         implementation "com.commercetools.sdk.jvm.core:commercetools-java-client:${depVersions.commercetoolsSdkJvm}"
         implementation "com.commercetools.sdk.jvm.core:commercetools-models:${depVersions.commercetoolsSdkJvm}"
         implementation "com.commercetools.sdk.jvm.core:commercetools-convenience:${depVersions.commercetoolsSdkJvm}"

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/TypeCacheLoader.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/ctp/TypeCacheLoader.java
@@ -1,12 +1,12 @@
 package com.commercetools.pspadapter.payone.domain.ctp;
 
-import com.google.common.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.queries.TypeQuery;
 
-public class TypeCacheLoader extends CacheLoader<String, Type> {
+public class TypeCacheLoader implements CacheLoader<String, Type> {
     private final BlockingSphereClient client;
 
     public TypeCacheLoader(BlockingSphereClient client) {

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/BaseDefaultTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/BaseDefaultTransactionExecutor.java
@@ -9,7 +9,7 @@ import com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResp
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus;
 import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.client.BlockingSphereClient;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutor.java
@@ -3,7 +3,8 @@ package com.commercetools.pspadapter.payone.transaction;
 import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
-import com.google.common.cache.LoadingCache;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.sphere.sdk.payments.Transaction;
 import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.types.CustomFields;
@@ -109,7 +110,7 @@ public abstract class IdempotentTransactionExecutor implements TransactionExecut
                 .getInterfaceInteractions()
                 .stream()
                 .filter(i -> Arrays.stream(typeKeys)
-                        .map(t -> getTypeCache().getUnchecked(t).toReference())
+                        .map(t -> getTypeCache().get(t).toReference())
                         .anyMatch(t -> t.getId().equals(i.getType().getId())));
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/TransactionBaseExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/TransactionBaseExecutor.java
@@ -5,7 +5,7 @@ import com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResp
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseErrorCode;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus;
 import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.sphere.sdk.client.BlockingSphereClient;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/AuthorizationTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/AuthorizationTransactionExecutor.java
@@ -5,7 +5,7 @@ import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.BaseRequest;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.commercetools.pspadapter.payone.transaction.BaseDefaultTransactionExecutor;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.types.Type;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/ChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/common/ChargeTransactionExecutor.java
@@ -5,7 +5,7 @@ import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.BaseRequest;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.commercetools.pspadapter.payone.transaction.BaseDefaultTransactionExecutor;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.types.Type;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceAuthorizationTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceAuthorizationTransactionExecutor.java
@@ -4,7 +4,7 @@ import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.types.Type;
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BankTransferInAdvanceChargeTransactionExecutor.java
@@ -4,7 +4,7 @@ import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.types.Type;
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/transaction/paymentinadvance/BaseBankTransferInAdvanceTransactionExecutor.java
@@ -9,7 +9,7 @@ import com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseSt
 import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.commercetools.pspadapter.payone.transaction.TransactionBaseExecutor;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.client.BlockingSphereClient;

--- a/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/tenant/TenantFactory.java
@@ -31,8 +31,9 @@ import com.commercetools.service.OrderServiceImpl;
 import com.commercetools.service.PaymentService;
 import com.commercetools.service.PaymentServiceImpl;
 import com.commercetools.util.SphereClientConfigurationUtil;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.client.QueueSphereClientDecorator;
@@ -305,7 +306,9 @@ public class TenantFactory {
     }
 
     protected LoadingCache<String, Type> createTypeCache(final BlockingSphereClient client) {
-        return CacheBuilder.newBuilder().build(new TypeCacheLoader(client));
+        return Caffeine.newBuilder()
+                       .maximumSize(1000)
+                       .build(new TypeCacheLoader(client));
     }
 
     @Nonnull

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/BaseTransaction_attemptExecutionTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/BaseTransaction_attemptExecutionTest.java
@@ -11,7 +11,7 @@ import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.carts.CartLike;
 import io.sphere.sdk.client.BlockingSphereClient;

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/IdempotentTransactionExecutorTest.java
@@ -3,15 +3,14 @@ package com.commercetools.pspadapter.payone.transaction;
 import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.ctp.TypeCacheLoader;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.Transaction;
 import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.queries.PagedQueryResult;
-import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.queries.TypeQuery;
 import org.junit.Before;
@@ -21,13 +20,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import util.PaymentTestHelper;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static util.JvmSdkMockUtil.pagedQueryResultsMock;
 
@@ -64,7 +60,7 @@ public class IdempotentTransactionExecutorTest {
             return PagedQueryResult.empty();
         });
 
-        testee = new TestIdempotentTransactionExecutor(CacheBuilder.newBuilder().build(new TypeCacheLoader(client)));
+        testee = new TestIdempotentTransactionExecutor(Caffeine.newBuilder().build(new TypeCacheLoader(client)));
     }
 
     @Test

--- a/service/src/test/java/com/commercetools/pspadapter/payone/transaction/common/AuthorizationTransactionExecutorTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/transaction/common/AuthorizationTransactionExecutorTest.java
@@ -5,7 +5,7 @@ import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
 import com.commercetools.pspadapter.payone.domain.ctp.TypeCacheLoader;
 import com.commercetools.pspadapter.payone.domain.payone.PayonePostService;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.payments.Payment;
@@ -69,7 +69,7 @@ public class AuthorizationTransactionExecutorTest {
         });
 
         testee = new AuthorizationTransactionExecutor(
-                CacheBuilder.newBuilder().build(new TypeCacheLoader(client)),
+                Caffeine.newBuilder().build(new TypeCacheLoader(client)),
                 requestFactory,
                 postService,
                 client

--- a/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
@@ -17,10 +17,9 @@ import com.commercetools.pspadapter.payone.domain.payone.model.klarna.KlarnaAuth
 import com.commercetools.pspadapter.payone.domain.payone.model.klarna.KlarnaPreauthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.wallet.WalletAuthorizationRequest;
 import com.commercetools.pspadapter.payone.domain.payone.model.wallet.WalletPreauthorizationRequest;
-import com.commercetools.pspadapter.payone.mapping.BankTransferWithoutIbanBicRequestFactory;
 import com.commercetools.pspadapter.payone.mapping.CountryToLanguageMapper;
 import com.commercetools.pspadapter.payone.mapping.PayoneRequestFactory;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.client.BlockingSphereClient;
@@ -44,7 +43,13 @@ import util.PaymentTestHelper;
 import javax.annotation.Nonnull;
 import java.util.Map;
 
-import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.*;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.BANK_TRANSFER_BANCONTACT;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.BANK_TRANSFER_IDEAL;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.INVOICE_KLARNA;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.WALLET_PAYDIREKT;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.WALLET_PAYPAL;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.supportedPaymentMethods;
+import static com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.PaymentMethod.supportedTransactionTypes;
 import static com.commercetools.pspadapter.payone.domain.payone.model.common.PayoneResponseFields.STATUS;
 import static com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus.APPROVED;
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.REFERENCE_FIELD;
@@ -55,7 +60,10 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TenantFactoryTest {


### PR DESCRIPTION
NOTE: guava dependency is still active, as it will be removed in base-branch when this and https://github.com/commercetools/commercetools-payone-integration/pull/367 is merged into `remove_guava_dependency `.