### PR TITLE
Set NoShipping to 1, When shipping address  is missing.

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
@@ -120,6 +120,7 @@ public class AuthorizationRequest extends BaseRequest {
 
     private String backurl;
 
+    private int noShipping;
 
     protected AuthorizationRequest(final PayoneConfig config, final String requestType, final String clearingtype) {
         super(config, requestType);
@@ -435,5 +436,13 @@ public class AuthorizationRequest extends BaseRequest {
 
     public void setBackurl(final String backurl) {
         this.backurl = backurl;
+    }
+
+    public int getNoShipping() {
+        return noShipping;
+    }
+
+    public void setNoShipping(int noShipping) {
+        this.noShipping = noShipping;
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
@@ -120,8 +120,6 @@ public class AuthorizationRequest extends BaseRequest {
 
     private String backurl;
 
-    private int noShipping;
-
     protected AuthorizationRequest(final PayoneConfig config, final String requestType, final String clearingtype) {
         super(config, requestType);
 
@@ -436,13 +434,5 @@ public class AuthorizationRequest extends BaseRequest {
 
     public void setBackurl(final String backurl) {
         this.backurl = backurl;
-    }
-
-    public int getNoShipping() {
-        return noShipping;
-    }
-
-    public void setNoShipping(int noShipping) {
-        this.noShipping = noShipping;
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/wallet/WalletAuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/wallet/WalletAuthorizationRequest.java
@@ -13,10 +13,13 @@ public class WalletAuthorizationRequest extends AuthorizationRequest {
 
     private String wallettype;
 
-    public WalletAuthorizationRequest(final PayoneConfig config, final ClearingType clearingType) {
+    private int noShipping;
+
+    public WalletAuthorizationRequest(final PayoneConfig config, final ClearingType clearingType, final int noShipping) {
         super(config, RequestType.AUTHORIZATION.getType(), clearingType.getPayoneCode());
 
         this.wallettype = clearingType.getSubType();
+        this.noShipping = noShipping;
     }
 
     //**************************************************************
@@ -26,5 +29,9 @@ public class WalletAuthorizationRequest extends AuthorizationRequest {
 
     public String getWallettype() {
         return wallettype;
+    }
+
+    public int getNoShipping() {
+        return noShipping;
     }
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/wallet/WalletPreauthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/wallet/WalletPreauthorizationRequest.java
@@ -13,10 +13,13 @@ public class WalletPreauthorizationRequest extends AuthorizationRequest {
 
     private String wallettype;
 
-    public WalletPreauthorizationRequest(final PayoneConfig config, final ClearingType clearingType) {
+    private int noShipping;
+
+    public WalletPreauthorizationRequest(final PayoneConfig config, final ClearingType clearingType, final int noShipping) {
         super(config, RequestType.PREAUTHORIZATION.getType(), clearingType.getPayoneCode());
 
         this.wallettype = clearingType.getSubType();
+        this.noShipping = noShipping;
     }
 
     //**************************************************************
@@ -27,4 +30,9 @@ public class WalletPreauthorizationRequest extends AuthorizationRequest {
     public String getWallettype() {
         return wallettype;
     }
+
+    public int getNoShipping() {
+        return noShipping;
+    }
+
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.payone.mapping;
 
 import com.commercetools.pspadapter.payone.domain.ctp.PaymentWithCartLike;
+import com.commercetools.pspadapter.payone.domain.ctp.paymentmethods.MethodKeys;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.AuthorizationRequest;
 import com.neovisionaries.i18n.CountryCode;
 import io.sphere.sdk.carts.CartLike;
@@ -127,33 +128,41 @@ public class MappingUtil {
                 });
     }
 
-    public static void mapShippingAddressToRequest(final AuthorizationRequest request, final Address shippingAddress) {
+    public static void mapShippingAddressToRequest(final AuthorizationRequest request,
+                                                   final Address shippingAddress,
+                                                   final String paymentMethod) {
 
-        final String shippingCountry = shippingAddress.getCountry().toLocale().getCountry();
-        final String shipping_street = joinStringsIgnoringNull(asList(shippingAddress.getStreetName(),
-            shippingAddress.getStreetNumber()));
-
-        if(shippingAddress == null
-            || StringUtils.isBlank(shippingAddress.getPostalCode())
-            || StringUtils.isBlank(shippingCountry)
-            || StringUtils.isBlank(shipping_street)
-            || StringUtils.isBlank(shippingAddress.getCity())
-        ) {
-            request.setNoShipping(1);
-        } else {
+        if(shippingAddress != null) {
             request.setShipping_firstname(shippingAddress.getFirstName());
             request.setShipping_lastname(shippingAddress.getLastName());
-            request.setShipping_street(shipping_street);
+            request.setShipping_street(joinStringsIgnoringNull(Arrays.asList(shippingAddress.getStreetName(),
+                shippingAddress.getStreetNumber())));
             request.setShipping_zip(shippingAddress.getPostalCode());
             request.setShipping_city(shippingAddress.getCity());
-            request.setShipping_country(shippingCountry);
+            request.setShipping_country(shippingAddress.getCountry().toLocale().getCountry());
             request.setShipping_company(joinStringsIgnoringNull(Arrays.asList(shippingAddress.getCompany(),
                 shippingAddress.getDepartment())));
 
             if (countriesWithStateAllowed.contains(shippingAddress.getCountry())) {
                 request.setShipping_state(shippingAddress.getState());
             }
+        } else if(!MethodKeys.WALLET_PAYPAL.equals(paymentMethod)) {
+            throw new IllegalArgumentException("Missing shipping address details");
         }
+    }
+
+    public static int checkForMissingShippingAddress(Address shippingAddress) {
+
+        if(shippingAddress == null
+            || StringUtils.isBlank(shippingAddress.getPostalCode())
+            || StringUtils.isBlank(shippingAddress.getCity())
+            || StringUtils.isBlank(shippingAddress.getCountry().toLocale().getCountry())
+            || StringUtils.isBlank(joinStringsIgnoringNull(asList(shippingAddress.getStreetName(),
+            shippingAddress.getStreetNumber())))
+        ) {
+            return 1;
+        }
+        return 0;
     }
 
     public static void mapCustomFieldsFromPayment(final AuthorizationRequest request, final CustomFields ctPaymentCustomFields) {

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/MappingUtil.java
@@ -129,22 +129,30 @@ public class MappingUtil {
 
     public static void mapShippingAddressToRequest(final AuthorizationRequest request, final Address shippingAddress) {
 
-        if(shippingAddress == null) {
-            throw new IllegalArgumentException("Missing shipping address details");
-        }
+        final String shippingCountry = shippingAddress.getCountry().toLocale().getCountry();
+        final String shipping_street = joinStringsIgnoringNull(asList(shippingAddress.getStreetName(),
+            shippingAddress.getStreetNumber()));
 
-        request.setShipping_firstname(shippingAddress.getFirstName());
-        request.setShipping_lastname(shippingAddress.getLastName());
-        request.setShipping_street(joinStringsIgnoringNull(Arrays.asList(shippingAddress.getStreetName(),
-            shippingAddress.getStreetNumber())));
-        request.setShipping_zip(shippingAddress.getPostalCode());
-        request.setShipping_city(shippingAddress.getCity());
-        request.setShipping_country(shippingAddress.getCountry().toLocale().getCountry());
-        request.setShipping_company(joinStringsIgnoringNull(Arrays.asList(shippingAddress.getCompany(),
-            shippingAddress.getDepartment())));
+        if(shippingAddress == null
+            || StringUtils.isBlank(shippingAddress.getPostalCode())
+            || StringUtils.isBlank(shippingCountry)
+            || StringUtils.isBlank(shipping_street)
+            || StringUtils.isBlank(shippingAddress.getCity())
+        ) {
+            request.setNoShipping(1);
+        } else {
+            request.setShipping_firstname(shippingAddress.getFirstName());
+            request.setShipping_lastname(shippingAddress.getLastName());
+            request.setShipping_street(shipping_street);
+            request.setShipping_zip(shippingAddress.getPostalCode());
+            request.setShipping_city(shippingAddress.getCity());
+            request.setShipping_country(shippingCountry);
+            request.setShipping_company(joinStringsIgnoringNull(Arrays.asList(shippingAddress.getCompany(),
+                shippingAddress.getDepartment())));
 
-        if (countriesWithStateAllowed.contains(shippingAddress.getCountry())) {
-            request.setShipping_state(shippingAddress.getState());
+            if (countriesWithStateAllowed.contains(shippingAddress.getCountry())) {
+                request.setShipping_state(shippingAddress.getState());
+            }
         }
     }
 

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/PayoneRequestFactory.java
@@ -101,7 +101,8 @@ public abstract class PayoneRequestFactory {
         }
 
         try {
-            MappingUtil.mapShippingAddressToRequest(request, ctCartLike.getShippingAddress());
+            MappingUtil.mapShippingAddressToRequest(request, ctCartLike.getShippingAddress(),
+                ctPayment.getPaymentMethodInfo().getMethod());
         } catch (final IllegalArgumentException ex) {
             logger.debug(
                 createTenantKeyValue(tenantConfig.getName()),

--- a/service/src/test/java/com/commercetools/main/BasicPaymentRequestWorkflow.java
+++ b/service/src/test/java/com/commercetools/main/BasicPaymentRequestWorkflow.java
@@ -2,24 +2,51 @@ package com.commercetools.main;
 
 import com.commercetools.Main;
 import com.commercetools.pspadapter.payone.config.PropertyProvider;
+import com.commercetools.pspadapter.payone.domain.ctp.CustomTypeBuilder;
+import com.commercetools.pspadapter.payone.mapping.CustomFieldKeys;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.carts.CartDraft;
+import io.sphere.sdk.carts.CartDraftBuilder;
+import io.sphere.sdk.carts.commands.CartCreateCommand;
+import io.sphere.sdk.carts.commands.CartUpdateCommand;
+import io.sphere.sdk.carts.commands.updateactions.AddPayment;
+import io.sphere.sdk.carts.commands.updateactions.SetBillingAddress;
+import io.sphere.sdk.carts.commands.updateactions.SetShippingAddress;
+import io.sphere.sdk.models.Address;
 import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.PaymentDraft;
+import io.sphere.sdk.payments.PaymentDraftBuilder;
+import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import io.sphere.sdk.payments.TransactionDraftBuilder;
 import io.sphere.sdk.payments.TransactionState;
+import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.commands.PaymentCreateCommand;
+import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
+import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.payments.queries.PaymentQuery;
 import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.queries.QueryPredicate;
+import io.sphere.sdk.types.CustomFieldsDraft;
+import io.sphere.sdk.utils.MoneyImpl;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.net.URISyntaxException;
+import javax.annotation.Nonnull;
+import javax.money.Monetary;
+import javax.money.MonetaryAmount;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.function.Function;
 
 import static com.commercetools.pspadapter.payone.domain.payone.PayonePostServiceImpl.executeGetRequest;
 import static com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus.APPROVED;
+import static com.commercetools.pspadapter.payone.domain.payone.model.common.ResponseStatus.REDIRECT;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static util.PaymentRequestHelperUtil.CTP_CLIENT;
@@ -37,10 +64,10 @@ import static util.PropertiesHelperUtil.getTenant;
 public class BasicPaymentRequestWorkflow {
 
     public static final int DEFAULT_PORT = 8080;
-    private final Map<String, String> testInternalProperties = new HashMap<>();
+    private static final Map<String, String> testInternalProperties = new HashMap<>();
 
-    @Before
-    public void setUp() throws URISyntaxException {
+    @BeforeClass
+    public static void setUp() {
         testInternalProperties.put("TENANTS", getTenant());
 
         testInternalProperties.put("TEST_DATA_CT_PROJECT_KEY", getProjectKey());
@@ -88,5 +115,68 @@ public class BasicPaymentRequestWorkflow {
                     assertThat(payment.getPaymentStatus().getInterfaceCode()).isEqualTo(APPROVED.toString());
                     assertThat(payment.getTransactions().get(0).getState()).isEqualTo(TransactionState.SUCCESS);
                 });
+    }
+
+    @Test
+    public void verifyPaypalWalletTransferPayoneAuthorizationRequestIsSuccess() throws Exception {
+        // Prepare
+        final String paymentId = preparePaymentWithAuthorizedAmountAndOrder();
+
+        // Test
+        final HttpResponse httpResponse = executeGetRequest(format(URL_HANDLE_PAYMENT+paymentId, DEFAULT_PORT));
+
+        // Assert
+        assertThat(httpResponse.getStatusLine().getStatusCode()).isIn(HttpStatus.SC_ACCEPTED, HttpStatus.SC_OK);
+
+        final PagedQueryResult<Payment> paymentPagedQueryResult =
+            CTP_CLIENT.execute(PaymentQuery.of()
+                                           .withPredicates(QueryPredicate.of(format("id=\"%s\"", paymentId))))
+                      .toCompletableFuture().join();
+
+        assertThat(paymentPagedQueryResult.getResults().get(0))
+            .satisfies(
+                payment -> {
+                    assertThat(payment.getPaymentStatus().getInterfaceCode()).isEqualTo(REDIRECT.toString());
+                });
+    }
+
+    @Nonnull
+    private static String preparePaymentWithAuthorizedAmountAndOrder() {
+        final Map<String, Object> customFieldKeysMap = new HashMap<>();
+        customFieldKeysMap.put(CustomFieldKeys.SUCCESS_URL_FIELD, "https://example.com/success");
+        customFieldKeysMap.put(CustomFieldKeys.ERROR_URL_FIELD, "https://example.com/error");
+        customFieldKeysMap.put(CustomFieldKeys.CANCEL_URL_FIELD, "https://example.com/cancel");
+        customFieldKeysMap.put(CustomFieldKeys.REDIRECT_URL_FIELD, "https://example.com/redirect");
+        customFieldKeysMap.put(CustomFieldKeys.REFERENCE_FIELD, String.valueOf(new Random().nextInt() + System.nanoTime()));
+        customFieldKeysMap.put(CustomFieldKeys.LANGUAGE_CODE_FIELD, "en");
+
+        final MonetaryAmount monetaryAmount = MoneyImpl.ofCents(4000, "EUR");
+        final PaymentDraft paymentDraft =
+            PaymentDraftBuilder.of(monetaryAmount)
+                               .paymentMethodInfo(PaymentMethodInfoBuilder.of()
+                                                                          .method("WALLET-PAYPAL")
+                                                                          .paymentInterface("PAYONE")
+                                                                          .build())
+                               .custom(CustomFieldsDraft.ofTypeKeyAndObjects(
+                                   CustomTypeBuilder.PAYMENT_WALLET, customFieldKeysMap))
+                               .build();
+
+        final Payment payment = CTP_CLIENT.executeBlocking(PaymentCreateCommand.of(paymentDraft));
+        final CartDraft cartDraft = CartDraftBuilder.of(Monetary.getCurrency("EUR")).build();
+
+        CTP_CLIENT.executeBlocking(CartUpdateCommand.of(
+            CTP_CLIENT.executeBlocking(CartCreateCommand.of(cartDraft)),
+            Arrays.asList(
+                AddPayment.of(payment),
+                SetShippingAddress.of(Address.of(CountryCode.DE)),
+                SetBillingAddress.of(Address.of(CountryCode.DE).withLastName("Test Buyer"))
+            )));
+
+        CTP_CLIENT.executeBlocking(PaymentUpdateCommand.of(payment, AddTransaction.of(TransactionDraftBuilder
+            .of(TransactionType.AUTHORIZATION, monetaryAmount, ZonedDateTime.now())
+            .state(TransactionState.PENDING)
+            .build())));
+
+        return payment.getId();
     }
 }

--- a/service/src/test/java/com/commercetools/main/BasicPaymentRequestWorkflowIT.java
+++ b/service/src/test/java/com/commercetools/main/BasicPaymentRequestWorkflowIT.java
@@ -61,7 +61,7 @@ import static util.PropertiesHelperUtil.getPayoneSubAccId;
 import static util.PropertiesHelperUtil.getProjectKey;
 import static util.PropertiesHelperUtil.getTenant;
 
-public class BasicPaymentRequestWorkflow {
+public class BasicPaymentRequestWorkflowIT {
 
     public static final int DEFAULT_PORT = 8080;
     private static final Map<String, String> testInternalProperties = new HashMap<>();

--- a/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BaseWalletRequestFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/payone/mapping/BaseWalletRequestFactoryTest.java
@@ -58,6 +58,7 @@ public class BaseWalletRequestFactoryTest extends BaseTenantPropertyTest {
         //clearing type
         softly.assertThat(result.getClearingtype()).isEqualTo(expectedClearingtype);
         softly.assertThat(result.getWallettype()).isEqualTo(expectedWalletType);
+        softly.assertThat(result.getNoShipping()).isEqualTo(0);
 
         //references
         softly.assertThat(result.getReference()).isEqualTo(paymentWithCartLike.getReference());
@@ -134,6 +135,7 @@ public class BaseWalletRequestFactoryTest extends BaseTenantPropertyTest {
         //clearing type
         softly.assertThat(result.getClearingtype()).isEqualTo(expectedClearingtype);
         softly.assertThat(result.getWallettype()).isEqualTo(expectedWalletType);
+        softly.assertThat(result.getNoShipping()).isEqualTo(0);
 
         //references
         softly.assertThat(result.getReference()).isEqualTo(paymentWithCartLike.getReference());

--- a/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
+++ b/service/src/test/java/com/commercetools/pspadapter/tenant/TenantFactoryTest.java
@@ -175,7 +175,7 @@ public class TenantFactoryTest {
     }
 
     @Test
-    public void createRequestFactory_paypal_authorization() throws Exception {
+    public void createRequestFactory_with_NoShippingAddress_paypal_authorization() throws Exception {
         PayoneRequestFactory requestFactory = factory.createRequestFactory(WALLET_PAYPAL, tenantConfig);
         PaymentWithCartLike paymentWithCartLike = testHelper.createPaypalPaymentWithCartLike();
         AuthorizationRequest authorizationRequest = requestFactory.createAuthorizationRequest(paymentWithCartLike);
@@ -185,6 +185,7 @@ public class TenantFactoryTest {
         assertThat(actual.get("request")).isEqualTo("authorization");
         assertThat(actual.get("clearingtype")).isEqualTo("wlt");
         assertThat(actual.get("wallettype")).isEqualTo("PPE");
+        assertThat(actual.get("noShipping")).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
- Add parameter `noShipping` to WalletPaymentTransfer.
- Set value 1 if Shipping Address is missing (any of the below values).
    - PostalCode
    - shippingCountry
    - shipping_street
    - city

related issue: https://github.com/commercetools/commercetools-payone-integration/issues/411

