### PR TITLE
Fix integration test for ConcurrentModificationException 

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/PaymentHandler.java
@@ -54,7 +54,17 @@ public class PaymentHandler {
     public PaymentHandleResult handlePayment(@Nonnull final String paymentId) {
         int retryCounter = 0;
         try {
-            return processPayment(paymentId);
+            for (; retryCounter < RETRIES_LIMIT; retryCounter++) {
+                try {
+                    return processPayment(paymentId);
+                } catch (final ConcurrentModificationException concurrentModificationException) {
+                    if (retryCounter == RETRIES_LIMIT - 1) {
+                        throw concurrentModificationException;
+                    } else {
+                        Thread.sleep(calculateVariableDelay(retryCounter));
+                    }
+                }
+            }
         } catch (final ConcurrentModificationException concurrentModificationException) {
             return handleConcurrentModificationException(paymentId, concurrentModificationException);
         } catch (final NotFoundException | NoCartLikeFoundException e) {
@@ -64,6 +74,8 @@ public class PaymentHandler {
         } catch (final Exception e) {
             return handleException(paymentId, retryCounter, e);
         }
+        return handleException(paymentId, retryCounter,
+                new Exception("Unknown workflow error in PaymentHandler#handlePayment"));
     }
 
     private PaymentHandleResult processPayment(@Nonnull final String paymentId)


### PR DESCRIPTION
To fix integration test for ConcurrentModificationException, we need to revert the change in paymentHandler which made in previous [PR](https://github.com/commercetools/commercetools-payone-integration/pull/424/files)