### PR TITLE
Add new field to klarna payment request.

### DIFF
--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/PayonePostServiceImpl.java
@@ -3,7 +3,6 @@ package com.commercetools.pspadapter.payone.domain.payone;
 import com.commercetools.pspadapter.payone.domain.payone.exceptions.PayoneException;
 import com.commercetools.pspadapter.payone.domain.payone.model.common.BaseRequest;
 import com.commercetools.util.PayoneHttpClientUtil;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Consts;
 import org.apache.http.HttpEntity;

--- a/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/domain/payone/model/common/AuthorizationRequest.java
@@ -120,6 +120,8 @@ public class AuthorizationRequest extends BaseRequest {
 
     private String backurl;
 
+    private String paymentData;
+
     protected AuthorizationRequest(final PayoneConfig config, final String requestType, final String clearingtype) {
         super(config, requestType);
 
@@ -435,4 +437,13 @@ public class AuthorizationRequest extends BaseRequest {
     public void setBackurl(final String backurl) {
         this.backurl = backurl;
     }
+
+    public String getPaymentData() {
+        return paymentData;
+    }
+
+    public void setPaymentData(String paymentData) {
+        this.paymentData = paymentData;
+    }
+
 }

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CustomFieldKeys.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/CustomFieldKeys.java
@@ -50,7 +50,7 @@ public final class CustomFieldKeys {
     public static final String IP_FIELD = "ip"; // IP_FIELD address, IPv4 or IPv6
     public static final String BIRTHDAY_FIELD = "birthday"; // Date of birth (YYYYMMDD), Mandatory for DE, NE and AT
     public static final String TELEPHONENUMBER_FIELD = "telephonenumber"; // if the value is set - overrides optional value from address.
-
+    public static final String ADD_PAYDATA_FIELD = "add_paydata";
     // iDeal
     public static final String BANK_GROUP_TYPE = "bankGroupType";
     public static final String BANK_COUNTRY = "bankCountry";

--- a/service/src/main/java/com/commercetools/pspadapter/payone/mapping/klarna/KlarnaRequestFactory.java
+++ b/service/src/main/java/com/commercetools/pspadapter/payone/mapping/klarna/KlarnaRequestFactory.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.ADD_PAYDATA_FIELD;
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.BIRTHDAY_FIELD;
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.IP_FIELD;
 import static com.commercetools.pspadapter.payone.mapping.CustomFieldKeys.TELEPHONENUMBER_FIELD;
@@ -71,7 +72,6 @@ public class KlarnaRequestFactory extends PayoneRequestFactory {
 
         mapFormPaymentWithCartLike(request, paymentWithCartLike);
         mapKlarnaMandatoryFields(request, paymentWithCartLike);
-
         //the line items, discounts and shipment cost are counted in the Klarna request constructor
 
         return request;
@@ -116,6 +116,7 @@ public class KlarnaRequestFactory extends PayoneRequestFactory {
 
         // override telephone number from billing address, if custom field is specified
         mapCustomFieldIfSignificant(customFields.getFieldAsString(TELEPHONENUMBER_FIELD), request::setTelephonenumber);
+        mapCustomFieldIfSignificant(customFields.getFieldAsString(ADD_PAYDATA_FIELD), request::setPaymentData);
     }
 
     /**


### PR DESCRIPTION
In this pr a new field  was added to the payone-request.
For adding this a special "field mapping" was added because the customobject field "add_paydata" has to be mapped to the request-parameter-name "add_paydata[action]"